### PR TITLE
feat: Implement i18n for Japanese and English

### DIFF
--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -1,0 +1,5 @@
+{
+  "greeting": "Hello!",
+  "farewell": "Goodbye!",
+  "heroTitle": "Production-Ready SaaS Template"
+}

--- a/locales/ja/common.json
+++ b/locales/ja/common.json
@@ -1,0 +1,5 @@
+{
+  "greeting": "こんにちは！",
+  "farewell": "さようなら！",
+  "heroTitle": "本番環境対応SaaSテンプレート"
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -11,6 +11,10 @@ const nextConfig = {
   experimental: {
     typedRoutes: true,
   },
+  i18n: {
+    locales: ['en', 'ja'],
+    defaultLocale: 'ja',
+  },
   eslint: {
     ignoreDuringBuilds: process.env.SKIP_LINTER === 'true'
   },

--- a/src/components/landing/hero.tsx
+++ b/src/components/landing/hero.tsx
@@ -1,12 +1,28 @@
 import { Button } from "@/components/ui/button";
 import { GITHUB_REPO_URL } from "@/constants";
 import Link from "next/link";
+import { useRouter } from "next/router";
 import ShinyButton from "@/components/ui/shiny-button";
 import { getTotalUsers } from "@/utils/stats";
 import { Suspense } from "react";
 import { Skeleton } from "@/components/ui/skeleton";
+import enCommon from "../../../locales/en/common.json";
+import jaCommon from "../../../locales/ja/common.json";
+
+const translations: Record<string, Record<string, string>> = {
+  en: enCommon,
+  ja: jaCommon,
+};
+
+function translate(locale: string, key: string, fallback: string): string {
+  return translations[locale]?.[key] || fallback;
+}
 
 export function Hero() {
+  const router = useRouter();
+  const locale = router.locale || router.defaultLocale || "en";
+  const heroTitle = translate(locale, "heroTitle", "Production-Ready SaaS Template");
+
   return (
     <div className="relative isolate pt-14 dark:bg-gray-900">
       <div className="pt-20 pb-24 sm:pt-20 sm:pb-32 lg:pb-40">
@@ -21,7 +37,7 @@ export function Hero() {
               </Suspense>
             </div>
             <h1 className="text-4xl font-bold tracking-tight sm:text-6xl bg-gradient-to-r from-indigo-500 to-purple-500 bg-clip-text text-transparent">
-              Production-Ready SaaS Template
+              {heroTitle}
             </h1>
             <p className="mt-6 text-lg leading-8 text-muted-foreground">
               A modern, open-source template for building SaaS applications with Next.js 15,

--- a/src/components/language-switcher.tsx
+++ b/src/components/language-switcher.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useRouter } from "next/router";
+import { Button } from "@/components/ui/button";
+
+export function LanguageSwitcher() {
+  const router = useRouter();
+  const { locale, pathname, query, asPath } = router;
+
+  const changeLanguage = (newLocale: string) => {
+    router.push({ pathname, query }, asPath, { locale: newLocale });
+  };
+
+  return (
+    <div className="flex items-center gap-2">
+      <Button
+        variant={locale === "en" ? "secondary" : "ghost"}
+        size="sm"
+        onClick={() => changeLanguage("en")}
+      >
+        English
+      </Button>
+      <Button
+        variant={locale === "ja" ? "secondary" : "ghost"}
+        size="sm"
+        onClick={() => changeLanguage("ja")}
+      >
+        日本語
+      </Button>
+    </div>
+  );
+}

--- a/src/components/nav-main.tsx
+++ b/src/components/nav-main.tsx
@@ -20,6 +20,7 @@ import {
 import Link from "next/link"
 import type { Route } from "next"
 import type { NavMainItem } from "./app-sidebar"
+import { LanguageSwitcher } from "@/components/language-switcher";
 
 type Props = {
   items: NavMainItem[]
@@ -87,6 +88,9 @@ export function NavMain({
           )
         })}
       </SidebarMenu>
+      <div className="mt-auto p-4">
+        <LanguageSwitcher />
+      </div>
     </SidebarGroup>
   )
 }


### PR DESCRIPTION
This commit introduces internationalization (i18n) to the application, supporting English and Japanese languages.

Key changes:
- Configured Next.js i18n with 'ja' as the default locale and 'en' as a supported locale.
- Created locale JSON files (`locales/en/common.json` and `locales/ja/common.json`) for translations.
- Updated the Hero component (`src/components/landing/hero.tsx`) to display a translated title based on the current locale. This uses a simple, direct import of JSON files for translations for now.
- Added a `LanguageSwitcher` component (`src/components/language-switcher.tsx`) that allows you to switch between English and Japanese.
- Integrated the `LanguageSwitcher` into the main navigation sidebar (`src/components/nav-main.tsx`).

The application should now default to Japanese, and you can switch to English using the new language switcher. The hero title on the main marketing page will reflect the selected language.