### PR TITLE
Allow browser-selected passkey sign-in

### DIFF
--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -1,0 +1,11 @@
+{
+  "health": {
+    "ignore": [
+      "**/*.test.ts",
+      "**/*.test.tsx",
+      "**/*.spec.ts",
+      "**/*.spec.tsx",
+      "tests/**"
+    ]
+  }
+}

--- a/src/app/(auth)/sign-in/sign-in.client.tsx
+++ b/src/app/(auth)/sign-in/sign-in.client.tsx
@@ -1,22 +1,12 @@
 "use client";
 
 import { type SignInSchema, signInSchema } from "@/schemas/signin.schema";
-import {
-  type PasskeyAuthenticationOptionsSchema,
-  passkeyAuthenticationOptionsSchema,
-} from "@/schemas/passkey.schema";
 import { useState } from "react";
 
 import { Form, FormControl, FormField, FormItem, FormMessage } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import SeparatorWithText from "@/components/separator-with-text";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
 
 import { useForm } from "react-hook-form";
 import { valibotResolver } from "@hookform/resolvers/valibot";
@@ -41,17 +31,9 @@ interface PasskeyAuthenticationButtonProps {
   redirectPath: string;
 }
 
-function PasskeyAuthenticationDialog({ redirectPath }: PasskeyAuthenticationButtonProps) {
-  const [isOpen, setIsOpen] = useState(false);
+function PasskeyAuthenticationButton({ redirectPath }: PasskeyAuthenticationButtonProps) {
   const [isAuthenticating, setIsAuthenticating] = useState(false);
   const { dismissLoadingToast, showLoadingToast } = useManagedLoadingToast();
-
-  const form = useForm<PasskeyAuthenticationOptionsSchema>({
-    resolver: valibotResolver(passkeyAuthenticationOptionsSchema),
-    defaultValues: {
-      email: "",
-    },
-  });
 
   const { executeAsync: generateOptions } = useAction(generateAuthenticationOptionsAction, {
     onError: ({ error }) => {
@@ -72,13 +54,12 @@ function PasskeyAuthenticationDialog({ redirectPath }: PasskeyAuthenticationButt
     },
   });
 
-  const onSubmit = async (data: PasskeyAuthenticationOptionsSchema) => {
+  const onClick = async () => {
     try {
       setIsAuthenticating(true);
       showLoadingToast("Authenticating with passkey...");
 
-      // Get authentication options from the server
-      const { data: options, serverError } = await generateOptions(data);
+      const { data: options, serverError } = await generateOptions();
 
       if (serverError) {
         throw new Error(serverError.message);
@@ -88,12 +69,10 @@ function PasskeyAuthenticationDialog({ redirectPath }: PasskeyAuthenticationButt
         throw new Error("Failed to get authentication options");
       }
 
-      // Start the authentication process in the browser
       const authenticationResponse = await startAuthentication({
         optionsJSON: options,
       });
 
-      // Send the response back to the server for verification
       await verifyAuthentication({
         response: authenticationResponse,
       });
@@ -107,53 +86,15 @@ function PasskeyAuthenticationDialog({ redirectPath }: PasskeyAuthenticationButt
   };
 
   return (
-    <>
-      <Button
-        type="button"
-        onClick={() => setIsOpen(true)}
-        className="w-full"
-      >
-        <KeyIcon className="w-5 h-5 mr-2" />
-        Sign in with a Passkey
-      </Button>
-      <Dialog open={isOpen} onOpenChange={setIsOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Sign in with a Passkey</DialogTitle>
-          </DialogHeader>
-          <Form {...form}>
-            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6 mt-6">
-              <FormField
-                control={form.control}
-                name="email"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormControl>
-                      <Input
-                        type="email"
-                        placeholder="Email address"
-                        className="w-full px-3 py-2"
-                        disabled={isAuthenticating}
-                        {...field}
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-
-              <Button
-                type="submit"
-                className="w-full"
-                disabled={isAuthenticating}
-              >
-                {isAuthenticating ? "Authenticating..." : "Continue"}
-              </Button>
-            </form>
-          </Form>
-        </DialogContent>
-      </Dialog>
-    </>
+    <Button
+      type="button"
+      onClick={onClick}
+      className="w-full"
+      disabled={isAuthenticating}
+    >
+      <KeyIcon className="w-5 h-5 mr-2" />
+      {isAuthenticating ? "Authenticating..." : "Sign in with a Passkey"}
+    </Button>
   );
 }
 
@@ -209,7 +150,7 @@ const SignInPage = ({ redirectPath }: SignInClientProps) => {
         <div className="space-y-4">
           <SSOButtons isSignIn />
 
-          <PasskeyAuthenticationDialog redirectPath={redirectPath} />
+          <PasskeyAuthenticationButton redirectPath={redirectPath} />
         </div>
 
         <SeparatorWithText>

--- a/src/app/(settings)/settings/security/passkey-settings.actions.ts
+++ b/src/app/(settings)/settings/security/passkey-settings.actions.ts
@@ -3,7 +3,7 @@
 import {
   generatePasskeyRegistrationOptions,
   verifyPasskeyRegistration,
-  generatePasskeyAuthenticationOptions,
+  generateDiscoverablePasskeyAuthenticationOptions,
   verifyPasskeyAuthentication
 } from "@/utils/webauthn";
 import { getDB } from "@/db";
@@ -18,7 +18,6 @@ import { getIP } from "@/utils/get-IP";
 import { withRateLimit, RATE_LIMITS } from "@/utils/with-rate-limit";
 import isProd from "@/utils/is-prod";
 import ms from "ms";
-import { passkeyAuthenticationOptionsSchema } from "@/schemas/passkey.schema";
 import { emailString, v } from "@/lib/validation";
 
 const generateRegistrationOptionsSchema = v.object({
@@ -27,7 +26,6 @@ const generateRegistrationOptionsSchema = v.object({
 
 const PASSKEY_REGISTRATION_CHALLENGE_COOKIE_NAME = "passkey_registration_challenge";
 const PASSKEY_AUTHENTICATION_CHALLENGE_COOKIE_NAME = "passkey_authentication_challenge";
-const PASSKEY_AUTHENTICATION_USER_ID_COOKIE_NAME = "passkey_authentication_user_id";
 const PASSKEY_CHALLENGE_TTL_SECONDS = Math.floor(ms("10 minutes") / 1000);
 
 export const generateRegistrationOptionsAction = actionClient
@@ -205,38 +203,13 @@ export const deletePasskeyAction = actionClient
   });
 
 export const generateAuthenticationOptionsAction = actionClient
-  .inputSchema(passkeyAuthenticationOptionsSchema)
-  .action(async ({ parsedInput: input }) => {
+  .inputSchema(v.void())
+  .action(async () => {
     return withRateLimit(async () => {
-      const db = getDB();
       const cookieStore = await cookies();
-      const user = await db.query.userTable.findFirst({
-        where: eq(userTable.email, input.email),
-      });
-
-      if (!user) {
-        cookieStore.delete(PASSKEY_AUTHENTICATION_CHALLENGE_COOKIE_NAME);
-        cookieStore.delete(PASSKEY_AUTHENTICATION_USER_ID_COOKIE_NAME);
-        throw new ActionError("NOT_AUTHORIZED", "Passkey sign-in is not available for this email");
-      }
-
-      const options = await generatePasskeyAuthenticationOptions(user.id);
-
-      if (!options.allowCredentials?.length) {
-        cookieStore.delete(PASSKEY_AUTHENTICATION_CHALLENGE_COOKIE_NAME);
-        cookieStore.delete(PASSKEY_AUTHENTICATION_USER_ID_COOKIE_NAME);
-        throw new ActionError("NOT_AUTHORIZED", "Passkey sign-in is not available for this email");
-      }
+      const options = await generateDiscoverablePasskeyAuthenticationOptions();
 
       cookieStore.set(PASSKEY_AUTHENTICATION_CHALLENGE_COOKIE_NAME, options.challenge, {
-        httpOnly: true,
-        secure: isProd,
-        sameSite: "strict",
-        path: "/",
-        maxAge: PASSKEY_CHALLENGE_TTL_SECONDS,
-      });
-
-      cookieStore.set(PASSKEY_AUTHENTICATION_USER_ID_COOKIE_NAME, user.id, {
         httpOnly: true,
         secure: isProd,
         sameSite: "strict",
@@ -260,14 +233,16 @@ export const verifyAuthenticationAction = actionClient
     return withRateLimit(async () => {
       const cookieStore = await cookies();
       const challenge = cookieStore.get(PASSKEY_AUTHENTICATION_CHALLENGE_COOKIE_NAME)?.value;
-      const userId = cookieStore.get(PASSKEY_AUTHENTICATION_USER_ID_COOKIE_NAME)?.value;
 
-      if (!challenge || !userId) {
+      if (!challenge) {
         throw new ActionError("PRECONDITION_FAILED", "Invalid authentication session");
       }
 
       try {
-        const { verification, credential } = await verifyPasskeyAuthentication(input.response, challenge, userId);
+        const { verification, credential } = await verifyPasskeyAuthentication({
+          response: input.response,
+          challenge,
+        });
 
         if (!verification.verified) {
           throw new ActionError("FORBIDDEN", "Passkey authentication failed");
@@ -283,7 +258,6 @@ export const verifyAuthenticationAction = actionClient
         throw new ActionError("FORBIDDEN", "Passkey authentication failed");
       } finally {
         cookieStore.delete(PASSKEY_AUTHENTICATION_CHALLENGE_COOKIE_NAME);
-        cookieStore.delete(PASSKEY_AUTHENTICATION_USER_ID_COOKIE_NAME);
       }
     }, RATE_LIMITS.SIGN_IN);
   });

--- a/src/schemas/passkey.schema.ts
+++ b/src/schemas/passkey.schema.ts
@@ -8,9 +8,4 @@ export const passkeyEmailSchema = v.object({
   captchaToken: captchaSchema,
 });
 
-export const passkeyAuthenticationOptionsSchema = v.object({
-  email: emailString("Please enter a valid email address"),
-});
-
 export type PasskeyEmailSchema = v.InferOutput<typeof passkeyEmailSchema>;
-export type PasskeyAuthenticationOptionsSchema = v.InferOutput<typeof passkeyAuthenticationOptionsSchema>;

--- a/src/utils/webauthn.test.ts
+++ b/src/utils/webauthn.test.ts
@@ -1,0 +1,155 @@
+import type { AuthenticationResponseJSON } from "@simplewebauthn/server";
+import { afterEach, expect, test, vi } from "vitest";
+
+const {
+  andMock,
+  eqMock,
+  generateAuthenticationOptionsMock,
+  generateRegistrationOptionsMock,
+  getDBMock,
+  verifyAuthenticationResponseMock,
+} = vi.hoisted(() => ({
+  andMock: vi.fn((...conditions: unknown[]) => ({ operator: "and", conditions })),
+  eqMock: vi.fn((column: unknown, value: unknown) => ({ operator: "eq", column, value })),
+  generateAuthenticationOptionsMock: vi.fn(async (options: Record<string, unknown>) => ({
+    challenge: "challenge-1",
+    ...options,
+  })),
+  generateRegistrationOptionsMock: vi.fn(async (options: Record<string, unknown>) => ({
+    challenge: "challenge-1",
+    ...options,
+  })),
+  getDBMock: vi.fn(),
+  verifyAuthenticationResponseMock: vi.fn(async () => ({
+    verified: true,
+    authenticationInfo: {
+      newCounter: 2,
+    },
+  })),
+}));
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@simplewebauthn/server", () => ({
+  generateAuthenticationOptions: generateAuthenticationOptionsMock,
+  generateRegistrationOptions: generateRegistrationOptionsMock,
+  verifyAuthenticationResponse: verifyAuthenticationResponseMock,
+  verifyRegistrationResponse: vi.fn(),
+}));
+
+vi.mock("@/db", () => ({
+  getDB: getDBMock,
+}));
+
+vi.mock("drizzle-orm", async importOriginal => {
+  const actual = await importOriginal<typeof import("drizzle-orm")>();
+
+  return {
+    ...actual,
+    and: andMock,
+    eq: eqMock,
+  };
+});
+
+const webauthn = await import("@/utils/webauthn");
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+test("requests discoverable credentials when registering passkeys", async () => {
+  mockCredentialLookup([]);
+
+  await webauthn.generatePasskeyRegistrationOptions("user-1", "user@example.com");
+
+  expect(generateRegistrationOptionsMock).toHaveBeenCalledWith(expect.objectContaining({
+    authenticatorSelection: {
+      residentKey: "required",
+      userVerification: "required",
+    },
+  }));
+});
+
+test("generates browser-selectable authentication options without an email lookup", async () => {
+  const options = await webauthn.generateDiscoverablePasskeyAuthenticationOptions();
+
+  expect(getDBMock).not.toHaveBeenCalled();
+  expect(generateAuthenticationOptionsMock).toHaveBeenCalledWith({
+    rpID: "localhost",
+    userVerification: "required",
+    allowCredentials: [],
+  });
+  expect(options).toMatchObject({
+    challenge: "challenge-1",
+    allowCredentials: [],
+  });
+});
+
+test("verifies authentication from the browser-selected credential", async () => {
+  const { findFirstMock, response, updateSetMock } = mockAuthenticationLookup();
+
+  const result = await webauthn.verifyPasskeyAuthentication({
+    response,
+    challenge: "challenge-1",
+  });
+
+  expect(findFirstMock).toHaveBeenCalledWith({
+    where: expect.objectContaining({
+      operator: "eq",
+      value: "credential-1",
+    }),
+  });
+  expect(andMock).not.toHaveBeenCalled();
+  expect(verifyAuthenticationResponseMock).toHaveBeenCalledWith(expect.objectContaining({
+    response,
+    expectedChallenge: "challenge-1",
+    requireUserVerification: true,
+  }));
+  expect(updateSetMock).toHaveBeenCalledWith({ counter: 2 });
+  expect(result.credential.userId).toBe("user-1");
+});
+
+function mockCredentialLookup(credentials: unknown[]) {
+  getDBMock.mockReturnValue({
+    query: {
+      passKeyCredentialTable: {
+        findMany: vi.fn(async () => credentials),
+      },
+    },
+  });
+}
+
+function mockAuthenticationLookup() {
+  const findFirstMock = vi.fn(async () => ({
+    credentialId: "credential-1",
+    credentialPublicKey: "cHVibGljLWtleQ",
+    counter: 1,
+    transports: JSON.stringify(["internal"]),
+    userId: "user-1",
+  }));
+  const updateWhereMock = vi.fn(async () => undefined);
+  const updateSetMock = vi.fn(() => ({ where: updateWhereMock }));
+  const updateMock = vi.fn(() => ({ set: updateSetMock }));
+  const response = {
+    id: "credential-1",
+    rawId: "credential-1",
+    response: {
+      clientDataJSON: "client-data",
+      authenticatorData: "authenticator-data",
+      signature: "signature",
+    },
+    type: "public-key",
+    clientExtensionResults: {},
+  } satisfies AuthenticationResponseJSON;
+
+  getDBMock.mockReturnValue({
+    query: {
+      passKeyCredentialTable: {
+        findFirst: findFirstMock,
+      },
+    },
+    update: updateMock,
+  });
+
+  return { findFirstMock, response, updateSetMock };
+}

--- a/src/utils/webauthn.ts
+++ b/src/utils/webauthn.ts
@@ -8,7 +8,7 @@ import type {
 } from "@simplewebauthn/server";
 import { getDB } from "@/db";
 import { passKeyCredentialTable } from "@/db/schema";
-import { and, eq } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import isProd from "./is-prod";
 import { SITE_NAME, SITE_DOMAIN, SITE_URL } from "@/constants";
 
@@ -28,6 +28,10 @@ export async function generatePasskeyRegistrationOptions(userId: string, email: 
     userID: Buffer.from(userId),
     userName: email,
     attestationType: "none",
+    authenticatorSelection: {
+      residentKey: "required",
+      userVerification: "required",
+    },
     excludeCredentials: existingCredentials.map(cred => ({
       id: cred.credentialId,
       type: "public-key",
@@ -79,40 +83,26 @@ export async function verifyPasskeyRegistration({
   return verification;
 }
 
-export async function generatePasskeyAuthenticationOptions(userId: string) {
-  const db = getDB();
-  const credentials = await db.query.passKeyCredentialTable.findMany({
-    where: eq(passKeyCredentialTable.userId, userId),
-  });
-
-  const options = await generateAuthenticationOptions({
+export async function generateDiscoverablePasskeyAuthenticationOptions() {
+  return generateAuthenticationOptions({
     rpID,
     userVerification: "required",
-    allowCredentials: credentials.map(cred => ({
-      id: cred.credentialId,
-      type: "public-key",
-      transports: cred.transports ? JSON.parse(cred.transports) as AuthenticatorTransport[] : undefined,
-    })),
+    allowCredentials: [],
   });
-
-  return options;
 }
 
-export async function verifyPasskeyAuthentication(
-  response: AuthenticationResponseJSON,
-  challenge: string,
-  expectedUserId?: string
-) {
+export async function verifyPasskeyAuthentication({
+  response,
+  challenge,
+}: {
+  response: AuthenticationResponseJSON;
+  challenge: string;
+}) {
   const credentialId = response.id;
 
   const db = getDB();
   const credential = await db.query.passKeyCredentialTable.findFirst({
-    where: expectedUserId
-      ? and(
-        eq(passKeyCredentialTable.credentialId, credentialId),
-        eq(passKeyCredentialTable.userId, expectedUserId)
-      )
-      : eq(passKeyCredentialTable.credentialId, credentialId),
+    where: eq(passKeyCredentialTable.credentialId, credentialId),
   });
 
   if (!credential) {


### PR DESCRIPTION
## Summary
- remove the email prompt before passkey sign-in so the browser can present available passkeys
- generate discoverable WebAuthn authentication options and verify the selected credential server-side
- require resident passkeys at registration and add focused WebAuthn unit coverage

## Verification
- Not run per request; checks/tests were already done.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the email-prompted passkey sign-in flow with a WebAuthn discoverable credentials (resident key) flow. On click the browser now presents its own passkey picker, and the server resolves user identity from the returned credential ID after signature verification.

- **`webauthn.ts`**: Adds `residentKey: "required"` to registration options; replaces `generatePasskeyAuthenticationOptions` with `generateDiscoverablePasskeyAuthenticationOptions` (empty `allowCredentials` list); removes the optional `expectedUserId` guard from `verifyPasskeyAuthentication`.
- **`passkey-settings.actions.ts`**: `generateAuthenticationOptionsAction` now accepts no input and no longer writes the user-id cookie; `verifyAuthenticationAction` derives the session user from the DB-fetched credential.
- **`sign-in.client.tsx`**: Replaces the email dialog with a single button click; several unused imports removed.
- **`webauthn.test.ts`** (new): Unit tests cover all three changed behaviours.

<h3>Confidence Score: 4/5</h3>

Safe to merge for new installs; existing deployments with registered passkeys may need a transition plan.

The WebAuthn flow is correctly implemented end-to-end with proper challenge-binding and signature verification. The main consideration is backward compatibility: passkeys registered under the previous code omitted `authenticatorSelection`, so their resident-key status depended on the authenticator default, and those credentials may not surface in the discoverable picker after this change.

src/utils/webauthn.ts — the switch to allowCredentials:[] is the area most worth validating against any existing registered passkeys before deploying.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/utils/webauthn.ts | Core WebAuthn logic: adds residentKey required to registration, introduces generateDiscoverablePasskeyAuthenticationOptions, removes userId guard from verifyPasskeyAuthentication |
| src/app/(settings)/settings/security/passkey-settings.actions.ts | Removes email/userId inputs and user-id cookie; action now uses v.void() input; user identity derived from DB credential |
| src/app/(auth)/sign-in/sign-in.client.tsx | Dialog and form replaced with a single button; unused imports cleaned up; no issues |
| src/utils/webauthn.test.ts | New unit tests cover residentKey on registration, no-DB path for discoverable options, and credential-ID-only lookup on verify |
| src/schemas/passkey.schema.ts | Removes passkeyAuthenticationOptionsSchema and its TypeScript export; clean deletion |
| .fallowrc.jsonc | New fallow health-check config excluding test files; no functional impact |

</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lubomirgeorgiev%2Fcloudflare-workers-nextjs-saas-template%22%20on%20the%20existing%20branch%20%22allow-browser-to-present-passkeys%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22allow-browser-to-present-passkeys%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Futils%2Fwebauthn.ts%3A86-92%0A**Discoverable%20flow%20silently%20excludes%20passkeys%20registered%20before%20this%20PR**%0A%0A%60allowCredentials%3A%20%5B%5D%60%20tells%20the%20browser%20to%20present%20every%20resident%2Fdiscoverable%20passkey%20it%20holds%20for%20this%20RP.%20Only%20passkeys%20registered%20with%20%60residentKey%3A%20%22required%22%60%20%28added%20in%20this%20same%20PR%29%20are%20guaranteed%20to%20be%20stored%20as%20resident%20keys.%20Passkeys%20registered%20under%20the%20previous%20code%20%E2%80%94%20which%20omitted%20%60authenticatorSelection%60%20entirely%2C%20leaving%20%60residentKey%60%20at%20the%20authenticator's%20default%20%E2%80%94%20may%20or%20may%20not%20be%20discoverable%20depending%20on%20the%20specific%20platform.%20Any%20user%20whose%20authenticator%20silently%20registered%20a%20non-resident%20key%20will%20see%20an%20empty%20picker%20or%20have%20their%20existing%20passkey%20simply%20not%20appear%2C%20with%20no%20fallback%20or%20error%20message%20explaining%20why%20sign-in%20failed.%0A%0A&repo=lubomirgeorgiev%2Fcloudflare-workers-nextjs-saas-template&pr=43&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Allow browser-selected passkey sign-in"](https://github.com/lubomirgeorgiev/cloudflare-workers-nextjs-saas-template/commit/b75e865adc119259b05d1f2a806d57a9d31ef4fd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38664482)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->