### PR TITLE
Fix i18n

### DIFF
--- a/src/actions/session.action.ts
+++ b/src/actions/session.action.ts
@@ -17,19 +17,17 @@ export const updateSelectedTeamAction = actionClient
       const session = await getSessionFromCookie();
 
       if (!session) {
-        throw new ActionError(
-          "FORBIDDEN",
-          "You must be logged in to update your selected team"
-        );
+        throw new ActionError("FORBIDDEN", {
+          key: "Client.Dashboard.Teams.errorMustBeLoggedIn",
+        });
       }
 
       if (input.selectedTeam && session.teams) {
         const teamExists = session.teams.some(team => team.id === input.selectedTeam);
         if (!teamExists) {
-          throw new ActionError(
-            "FORBIDDEN",
-            "Team not found or you are not a member"
-          );
+          throw new ActionError("FORBIDDEN", {
+            key: "Client.Dashboard.Teams.errorTeamNotFoundOrNotMember",
+          });
         }
       }
 
@@ -40,10 +38,9 @@ export const updateSelectedTeamAction = actionClient
       );
 
       if (!updatedSession) {
-        throw new ActionError(
-          "INTERNAL_SERVER_ERROR",
-          "Failed to update selected team"
-        );
+        throw new ActionError("INTERNAL_SERVER_ERROR", {
+          key: "Client.Dashboard.Teams.errorUpdateSelectedTeam",
+        });
       }
 
       return {
@@ -57,9 +54,8 @@ export const updateSelectedTeamAction = actionClient
         throw error;
       }
 
-      throw new ActionError(
-        "INTERNAL_SERVER_ERROR",
-        "Failed to update selected team"
-      );
+      throw new ActionError("INTERNAL_SERVER_ERROR", {
+        key: "Client.Dashboard.Teams.errorUpdateSelectedTeam",
+      });
     }
   });

--- a/src/actions/team-actions.ts
+++ b/src/actions/team-actions.ts
@@ -18,7 +18,7 @@ export const createTeamAction = actionClient
   .action(async ({ parsedInput: input }) => {
     return runVerifiedAction({
       actionName: "Failed to create team",
-      failureMessage: "Failed to create team",
+      failureMessageKey: "Client.Dashboard.Teams.toastCreateError",
       handler: () => createTeam(input),
     });
   });
@@ -27,7 +27,7 @@ export const getUserTeamsAction = actionClient
   .action(async () => {
     return runVerifiedAction({
       actionName: "Failed to get user teams",
-      failureMessage: "Failed to get user teams",
+      failureMessageKey: "Client.Dashboard.Teams.errorGetTeams",
       handler: getUserTeams,
     });
   });

--- a/src/actions/team-membership-actions.ts
+++ b/src/actions/team-membership-actions.ts
@@ -35,7 +35,7 @@ export const inviteUserAction = actionClient
       async () => {
         return runVerifiedAction({
           actionName: "Failed to invite user",
-          failureMessage: "Failed to invite user",
+          failureMessageKey: "Client.Dashboard.Teams.toastInviteError",
           handler: () => inviteUserToTeam(input),
         });
       },
@@ -48,7 +48,7 @@ export const removeTeamMemberAction = actionClient
   .action(async ({ parsedInput: input }) => {
     return runVerifiedAction({
       actionName: "Failed to remove team member",
-      failureMessage: "Failed to remove team member",
+      failureMessageKey: "Client.Dashboard.Teams.toastRemoveError",
       handler: () => removeTeamMember(input),
     });
   });
@@ -58,7 +58,7 @@ export const acceptInvitationAction = actionClient
   .action(async ({ parsedInput: input }) => {
     return runVerifiedAction({
       actionName: "Failed to accept invitation",
-      failureMessage: "Failed to accept invitation",
+      failureMessageKey: "Client.Dashboard.Teams.errorAcceptInvitation",
       handler: () => acceptTeamInvitation(input.token),
     });
   });
@@ -67,7 +67,7 @@ export const getPendingInvitationsForCurrentUserAction = actionClient
   .action(async () => {
     return runVerifiedAction({
       actionName: "Failed to get pending team invitations",
-      failureMessage: "Failed to get pending team invitations",
+      failureMessageKey: "Client.Dashboard.Teams.errorGetPendingInvitations",
       handler: getPendingInvitationsForCurrentUser,
     });
   });

--- a/src/app/(admin)/admin/_components/users/columns.tsx
+++ b/src/app/(admin)/admin/_components/users/columns.tsx
@@ -4,6 +4,7 @@ import { ColumnDef } from "@tanstack/react-table"
 import { MoreHorizontal } from "lucide-react"
 import { format } from "date-fns"
 import { formatRelativeDateTime } from "@/utils/format-date"
+import { DEFAULT_LOCALE } from "@/i18n/config"
 
 import { Button } from "@/components/ui/button"
 import {
@@ -71,7 +72,7 @@ export const columns: ColumnDef<User>[] = [
       return (
         <Tooltip>
           <TooltipTrigger>
-            {formatRelativeDateTime(date)}
+            {formatRelativeDateTime(date, DEFAULT_LOCALE)}
           </TooltipTrigger>
           <TooltipContent>
             <p>{formattedDate}</p>

--- a/src/app/(admin)/admin/cms/[collection]/_components/cms-entries-table.tsx
+++ b/src/app/(admin)/admin/cms/[collection]/_components/cms-entries-table.tsx
@@ -138,7 +138,7 @@ export function CmsEntriesTable({
           <CmsEntryStatusBadge status={row.original.status} />
           {(row.original.publishedAt && row.original.status === "scheduled") && (
             <span className="text-xs text-muted-foreground">
-              {formatRelativeDateTime(row.original.publishedAt)}
+              {formatRelativeDateTime(row.original.publishedAt, DEFAULT_LOCALE)}
             </span>
           )}
         </div>
@@ -171,7 +171,7 @@ export function CmsEntriesTable({
       cell: ({ row }) => (
         <span>
           {row.original.updatedAt
-            ? formatRelativeDateTime(row.original.updatedAt)
+            ? formatRelativeDateTime(row.original.updatedAt, DEFAULT_LOCALE)
             : "—"}
         </span>
       ),

--- a/src/app/(admin)/admin/cms/[collection]/_components/cms-entry-form.tsx
+++ b/src/app/(admin)/admin/cms/[collection]/_components/cms-entry-form.tsx
@@ -10,6 +10,7 @@ import { listCmsTagsAction, createCmsTagAction } from "../../../_actions/cms-tag
 import { getCmsEntryVersionCountAction } from "../../_actions/version-actions";
 import { cmsEntryFormSchema, type CmsEntryFormData, type CmsEntryFormInput } from "@/schemas/cms-entry.schema";
 import { formatRelativeDateTime } from "@/utils/format-date";
+import { DEFAULT_LOCALE } from "@/i18n/config";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -870,19 +871,19 @@ export function CmsEntryForm({
                   <div>
                     <span className="text-muted-foreground">Created:</span>
                     <p className="font-medium">
-                      {formatRelativeDateTime(entry.createdAt)}
+                      {formatRelativeDateTime(entry.createdAt, DEFAULT_LOCALE)}
                     </p>
                     <p className="text-xs text-muted-foreground mt-0.5">
-                      {formatDateTime(entry.createdAt)}
+                      {formatDateTime(entry.createdAt, DEFAULT_LOCALE)}
                     </p>
                   </div>
                   <div>
                     <span className="text-muted-foreground">Last Updated:</span>
                     <p className="font-medium">
-                      {formatRelativeDateTime(entry.updatedAt)}
+                      {formatRelativeDateTime(entry.updatedAt, DEFAULT_LOCALE)}
                     </p>
                     <p className="text-xs text-muted-foreground mt-0.5">
-                      {formatDateTime(entry.updatedAt)}
+                      {formatDateTime(entry.updatedAt, DEFAULT_LOCALE)}
                     </p>
                   </div>
                   {entry.publishedAt && (
@@ -891,10 +892,10 @@ export function CmsEntryForm({
                         {entry.status === CMS_ENTRY_STATUS.SCHEDULED ? "Scheduled for:" : "Published:"}
                       </span>
                       <p className="font-medium">
-                        {formatRelativeDateTime(entry.publishedAt)}
+                        {formatRelativeDateTime(entry.publishedAt, DEFAULT_LOCALE)}
                       </p>
                       <p className="text-xs text-muted-foreground mt-0.5">
-                        {formatDateTime(entry.publishedAt)}
+                        {formatDateTime(entry.publishedAt, DEFAULT_LOCALE)}
                       </p>
                     </div>
                   )}

--- a/src/app/(admin)/admin/cms/[collection]/_components/version-history.tsx
+++ b/src/app/(admin)/admin/cms/[collection]/_components/version-history.tsx
@@ -23,6 +23,7 @@ import type { CmsEntryVersion } from "@/db/schema";
 import { useAction } from "next-safe-action/hooks";
 import { revertCmsEntryVersionAction, getCmsEntryVersionsAction, deleteCmsEntryVersionAction } from "../../_actions/version-actions";
 import { formatRelativeDateTime } from "@/utils/format-date";
+import { DEFAULT_LOCALE } from "@/i18n/config";
 import { toast } from "sonner";
 import type { GetCmsCollectionResult } from "@/lib/cms/entry";
 import { ALERT_BLOCK_NODE_NAME } from "@/components/tiptap-node/alert-block/alert-block-types";
@@ -757,7 +758,7 @@ export function VersionHistory({
                        </div>
                        <div className="flex items-center text-xs text-muted-foreground gap-1">
                          <Clock className="h-3 w-3" />
-                         {formatRelativeDateTime(version.createdAt)}
+                         {formatRelativeDateTime(version.createdAt, DEFAULT_LOCALE)}
                        </div>
                      </button>
                      {canDelete && (
@@ -783,10 +784,10 @@ export function VersionHistory({
                 <div className="p-4 border-b bg-muted/10 flex justify-between items-center">
                   <div>
                     <h3 className="font-medium">
-                      Comparing Version {selectedVersion.versionNumber} ({formatRelativeDateTime(selectedVersion.createdAt)})
+                      Comparing Version {selectedVersion.versionNumber} ({formatRelativeDateTime(selectedVersion.createdAt, DEFAULT_LOCALE)})
                     </h3>
                     <p className="text-xs text-muted-foreground">
-                      Changes needed to restore this version from the current entry{currentVersion ? ` (${formatRelativeDateTime(currentVersion.createdAt)})` : ''}
+                      Changes needed to restore this version from the current entry{currentVersion ? ` (${formatRelativeDateTime(currentVersion.createdAt, DEFAULT_LOCALE)})` : ''}
                     </p>
                   </div>
                   <div className="flex gap-2">

--- a/src/app/(admin)/admin/cms/media/[mediaId]/page.tsx
+++ b/src/app/(admin)/admin/cms/media/[mediaId]/page.tsx
@@ -11,7 +11,8 @@ import Image from "next/image";
 import { EditAltText } from "./_components/edit-alt-text";
 import { cmsConfig, type CollectionsUnion } from "@/../cms.config";
 import { CmsEntryStatusBadge } from "../../_components/cms-entry-status-badge";
-import { formatRelativeDateTime } from "@/utils/format-date";
+import { formatDateTime, formatRelativeDateTime } from "@/utils/format-date";
+import { DEFAULT_LOCALE } from "@/i18n/config";
 
 export const metadata: Metadata = {
   title: "Media Details | Admin",
@@ -136,10 +137,10 @@ export default async function MediaDetailPage({ params }: MediaDetailPageProps) 
             <div>
               <p className="text-sm font-medium text-muted-foreground">Uploaded</p>
               <p className="mt-1">
-                {formatRelativeDateTime(media.createdAt)}
+                {formatRelativeDateTime(media.createdAt, DEFAULT_LOCALE)}
               </p>
               <p className="text-xs text-muted-foreground">
-                {new Date(media.createdAt).toLocaleString()}
+                {formatDateTime(media.createdAt, DEFAULT_LOCALE)}
               </p>
             </div>
             <div>

--- a/src/app/(admin)/admin/cms/media/_components/media-list-table.tsx
+++ b/src/app/(admin)/admin/cms/media/_components/media-list-table.tsx
@@ -15,6 +15,7 @@ import { CMS_IMAGES_API_ROUTE } from "@/constants";
 import Image from "next/image";
 import { MediaTableActions } from "./media-table-actions";
 import { formatRelativeDateTime } from "@/utils/format-date";
+import { DEFAULT_LOCALE } from "@/i18n/config";
 
 interface MediaListTableProps {
   page: number;
@@ -125,7 +126,7 @@ export async function MediaListTable({ page }: MediaListTableProps) {
                   )}
                 </TableCell>
                 <TableCell className="text-muted-foreground text-sm">
-                  {formatRelativeDateTime(item.createdAt)}
+                  {formatRelativeDateTime(item.createdAt, DEFAULT_LOCALE)}
                 </TableCell>
                 <TableCell className="text-right">
                   <div className="flex items-center justify-end gap-2">

--- a/src/app/(admin)/admin/jobs/jobs-tables.tsx
+++ b/src/app/(admin)/admin/jobs/jobs-tables.tsx
@@ -21,6 +21,7 @@ import type {
   ScheduledJobTableRow,
 } from "@/lib/scheduler/admin";
 import { formatDateTime, formatRelativeDateTime } from "@/utils/format-date";
+import { DEFAULT_LOCALE } from "@/i18n/config";
 
 const JOBS_PAGE_SIZE_OPTIONS = [10, 20, 50];
 
@@ -101,9 +102,9 @@ const d1JobColumns: ColumnDef<ScheduledJobTableRow>[] = [
     header: "Run At",
     cell: ({ row }) => (
       <div className="whitespace-nowrap">
-        <div>{formatRelativeDateTime(row.original.runAt)}</div>
+        <div>{formatRelativeDateTime(row.original.runAt, DEFAULT_LOCALE)}</div>
         <div className="text-xs text-muted-foreground">
-          {formatDateTime(row.original.runAt)}
+          {formatDateTime(row.original.runAt, DEFAULT_LOCALE)}
         </div>
       </div>
     ),
@@ -138,7 +139,7 @@ const queueMessageColumns: ColumnDef<QueueMessageTableRow>[] = [
     accessorKey: "publishedAt",
     header: "Published",
     cell: ({ row }) => (
-      <span className="whitespace-nowrap">{formatDateTime(row.original.publishedAt)}</span>
+      <span className="whitespace-nowrap">{formatDateTime(row.original.publishedAt, DEFAULT_LOCALE)}</span>
     ),
   },
   {
@@ -207,7 +208,7 @@ function QueueMetrics({ queueMetrics }: { queueMetrics: QueueMetricsTableState }
     {
       label: "Oldest message",
       value: queueMetrics.oldestMessageTimestamp
-        ? formatDateTime(queueMetrics.oldestMessageTimestamp)
+        ? formatDateTime(queueMetrics.oldestMessageTimestamp, DEFAULT_LOCALE)
         : "None",
     },
   ];

--- a/src/app/(dashboard)/dashboard/billing/page.tsx
+++ b/src/app/(dashboard)/dashboard/billing/page.tsx
@@ -1,6 +1,7 @@
 import type { Route } from "next";
 import { redirect } from "next/navigation";
 import { getSessionFromCookie } from "@/utils/auth";
+import { redirectToSignIn } from "@/utils/auth-redirect";
 
 // Team billing lives at /dashboard/teams/[teamSlug]/billing. This thin redirect points
 // the generic nav "Billing" item at the session's selected team so nav stays team-agnostic.
@@ -8,7 +9,7 @@ export default async function BillingRedirectPage() {
   const session = await getSessionFromCookie();
 
   if (!session) {
-    redirect("/sign-in?redirect=/dashboard/billing");
+    return redirectToSignIn("/dashboard/billing");
   }
 
   const teams = session.teams ?? [];

--- a/src/app/(dashboard)/dashboard/teams/[teamSlug]/billing/_components/addon-cards.tsx
+++ b/src/app/(dashboard)/dashboard/teams/[teamSlug]/billing/_components/addon-cards.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { useAction } from "next-safe-action/hooks";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { toast } from "sonner";
 import { Minus, Plus } from "lucide-react";
 
@@ -98,6 +98,7 @@ interface AddonCardProps {
 
 function AddonCard({ addonId, active, interval, canEdit, isExecuting, onUpdate }: AddonCardProps) {
   const t = useTranslations("Client.Dashboard.Billing");
+  const locale = useLocale();
   const [quantity, setQuantity] = useState(active);
 
   const addon = TEAM_ADDONS[addonId];
@@ -118,7 +119,7 @@ function AddonCard({ addonId, active, interval, canEdit, isExecuting, onUpdate }
   const summary = [
     grantedSeats > 0 ? t("addonSeatsGrant", { seats: grantedSeats }) : null,
     grantedProjects > 0 ? t("addonProjectsGrant", { projects: grantedProjects }) : null,
-    `${formatPrice({ amount: unitAmount * quantity, currency: addon.currency })}${intervalSuffix}`,
+    `${formatPrice({ amount: unitAmount * quantity, currency: addon.currency, locale })}${intervalSuffix}`,
   ].filter(Boolean).join(" · ");
 
   return (
@@ -132,7 +133,7 @@ function AddonCard({ addonId, active, interval, canEdit, isExecuting, onUpdate }
         </div>
         {description && <p className="text-sm text-muted-foreground">{description}</p>}
         <div className="text-3xl font-bold">
-          {formatPrice({ amount: unitAmount, currency: addon.currency })}
+          {formatPrice({ amount: unitAmount, currency: addon.currency, locale })}
           <span className="text-base font-normal text-muted-foreground">
             {intervalSuffix} {t("addonEach")}
           </span>

--- a/src/app/(dashboard)/dashboard/teams/[teamSlug]/billing/_components/plan-cards.tsx
+++ b/src/app/(dashboard)/dashboard/teams/[teamSlug]/billing/_components/plan-cards.tsx
@@ -3,7 +3,7 @@
 import { useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useAction } from "next-safe-action/hooks";
-import { useFormatter, useTranslations } from "next-intl";
+import { useFormatter, useLocale, useTranslations } from "next-intl";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
@@ -94,6 +94,7 @@ export function PlanCards({
   isTrialEligible,
 }: PlanCardsProps) {
   const t = useTranslations("Client.Dashboard.Billing");
+  const locale = useLocale();
   const format = useFormatter();
   const router = useRouter();
   const [paymentDialog, setPaymentDialog] = useState<PaymentDialogState | null>(null);
@@ -210,7 +211,7 @@ export function PlanCards({
       planId,
       interval,
       planName: plan.name,
-      priceLabel: `${formatPrice({ amount, currency: plan.currency })}${t(interval === "year" ? "perYear" : "perMonth")}`,
+      priceLabel: `${formatPrice({ amount, currency: plan.currency, locale })}${t(interval === "year" ? "perYear" : "perMonth")}`,
       ...options,
     });
   }
@@ -312,7 +313,7 @@ export function PlanCards({
           const isCurrent = planId === currentPlanId;
           const isFree = plan.amount === 0;
           const amount = getPlanAmount({ plan, interval: billingInterval });
-          const priceLabel = isFree ? t("freePrice") : formatPrice({ amount, currency: plan.currency });
+          const priceLabel = isFree ? t("freePrice") : formatPrice({ amount, currency: plan.currency, locale });
           // Whether the toggle matches the interval the team already pays on; legacy rows
           // without a recorded interval are treated as matching so no switch is offered.
           const matchesCurrentInterval = currentInterval === null || billingInterval === currentInterval;
@@ -352,7 +353,7 @@ export function PlanCards({
                 {!isFree && billingInterval === "year" && (
                   <p className="text-xs text-muted-foreground">
                     {t("yearlyEquivalentNote", {
-                      price: formatPrice({ amount: Math.round(amount / 12), currency: plan.currency }),
+                      price: formatPrice({ amount: Math.round(amount / 12), currency: plan.currency, locale }),
                     })}
                   </p>
                 )}

--- a/src/app/(dashboard)/dashboard/teams/[teamSlug]/billing/billing.actions.ts
+++ b/src/app/(dashboard)/dashboard/teams/[teamSlug]/billing/billing.actions.ts
@@ -31,7 +31,7 @@ import {
   teamBillingSchema,
   updateAddonQuantitySchema,
 } from "@/schemas/billing.schema";
-import { getLocale, getTranslations } from "next-intl/server";
+import { getLocale } from "next-intl/server";
 import { getStripeSubscriptionTransitionPolicy } from "@/constants/subscription-lifecycle";
 import { SITE_URL } from "@/constants";
 
@@ -44,8 +44,7 @@ function readClientSecret(subscription: Stripe.Subscription): string | null {
 
 async function assertBillingEnabled() {
   if (!isBillingEnabled()) {
-    const t = await getTranslations("Client.Dashboard.Billing");
-    throw new ActionError("PRECONDITION_FAILED", t("billingDisabledNotice"));
+    throw new ActionError("PRECONDITION_FAILED", { key: "Client.Dashboard.Billing.billingDisabledNotice" });
   }
 }
 
@@ -53,7 +52,6 @@ async function assertBillingEnabled() {
 // resume): asserts billing is enabled, requires the ACCESS_BILLING permission, and loads
 // the team's active subscription id (throwing if there is none).
 async function requireExistingSubscription(teamId: string) {
-  const t = await getTranslations("Client.Dashboard.Billing");
   await assertBillingEnabled();
   await requireTeamPermission(teamId, TEAM_PERMISSIONS.ACCESS_BILLING);
 
@@ -61,10 +59,10 @@ async function requireExistingSubscription(teamId: string) {
   const team = await getDB().query.teamTable.findFirst({ where: { id: teamId } });
 
   if (!team?.stripeSubscriptionId) {
-    throw new ActionError("PRECONDITION_FAILED", t("errorStartCheckout"));
+    throw new ActionError("PRECONDITION_FAILED", { key: "Client.Dashboard.Billing.errorStartCheckout" });
   }
 
-  return { t, stripe, subscriptionId: team.stripeSubscriptionId };
+  return { stripe, subscriptionId: team.stripeSubscriptionId };
 }
 
 // Settles whatever subscription the team currently records so a new checkout can claim
@@ -77,7 +75,6 @@ async function settleRecordedSubscription({
   teamId: string;
   recordedSubscriptionId: string;
 }) {
-  const t = await getTranslations("Client.Dashboard.Billing");
   const stripe = getStripe();
 
   const existing = await stripe.subscriptions
@@ -97,7 +94,7 @@ async function settleRecordedSubscription({
   const policy = getStripeSubscriptionTransitionPolicy(existing.status);
 
   if (!policy || policy.subscribe === "block") {
-    throw new ActionError("CONFLICT", t("errorStartCheckout"));
+    throw new ActionError("CONFLICT", { key: "Client.Dashboard.Billing.errorStartCheckout" });
   }
 
   // Do not create a replacement unless Stripe confirms the old subscription is
@@ -118,7 +115,6 @@ async function convergeOnWinningCheckout({
   teamId: string;
   losingSubscriptionId: string;
 }) {
-  const t = await getTranslations("Client.Dashboard.Billing");
   const stripe = getStripe();
 
   await stripe.subscriptions.cancel(losingSubscriptionId).catch((error: unknown) => {
@@ -136,7 +132,7 @@ async function convergeOnWinningCheckout({
   const clientSecret = winnerSubscription ? readClientSecret(winnerSubscription) : null;
 
   if (!winnerSubscription || !clientSecret) {
-    throw new ActionError("CONFLICT", t("errorStartCheckout"));
+    throw new ActionError("CONFLICT", { key: "Client.Dashboard.Billing.errorStartCheckout" });
   }
 
   return { success: true, clientSecret, subscriptionId: winnerSubscription.id };
@@ -146,7 +142,6 @@ export const createSubscriptionAction = actionClient
   .inputSchema(createSubscriptionSchema)
   .action(async ({ parsedInput: { teamId, planId, interval } }) => {
     return withRateLimit(async () => {
-      const t = await getTranslations("Client.Dashboard.Billing");
       await assertBillingEnabled();
 
       const session = await requireTeamPermission(teamId, TEAM_PERMISSIONS.ACCESS_BILLING);
@@ -193,7 +188,7 @@ export const createSubscriptionAction = actionClient
         const clientSecret = readClientSecret(subscription);
 
         if (!clientSecret) {
-          throw new ActionError("INTERNAL_SERVER_ERROR", t("errorNoClientSecret"));
+          throw new ActionError("INTERNAL_SERVER_ERROR", { key: "Client.Dashboard.Billing.errorNoClientSecret" });
         }
 
         return {
@@ -204,7 +199,7 @@ export const createSubscriptionAction = actionClient
       } catch (error) {
         if (error instanceof ActionError) throw error;
         console.error("createSubscriptionAction failed", error);
-        throw new ActionError("INTERNAL_SERVER_ERROR", t("errorPaymentProvider"));
+        throw new ActionError("INTERNAL_SERVER_ERROR", { key: "Client.Dashboard.Billing.errorPaymentProvider" });
       }
     }, RATE_LIMITS.BILLING);
   });
@@ -232,7 +227,6 @@ export const startTrialSetupAction = actionClient
   .inputSchema(createSubscriptionSchema)
   .action(async ({ parsedInput: { teamId, planId, interval } }) => {
     return withRateLimit(async () => {
-      const t = await getTranslations("Client.Dashboard.Billing");
       await assertBillingEnabled();
 
       const session = await requireTeamPermission(teamId, TEAM_PERMISSIONS.ACCESS_BILLING);
@@ -240,7 +234,7 @@ export const startTrialSetupAction = actionClient
 
       const trialDays = await resolveTrialDays({ teamId, planId, userId: session.user.id });
       if (trialDays <= 0) {
-        throw new ActionError("PRECONDITION_FAILED", t("errorTrialUnavailable"));
+        throw new ActionError("PRECONDITION_FAILED", { key: "Client.Dashboard.Billing.errorTrialUnavailable" });
       }
 
       const team = await getDB().query.teamTable.findFirst({ where: { id: teamId } });
@@ -262,14 +256,14 @@ export const startTrialSetupAction = actionClient
         });
 
         if (!setupIntent.client_secret) {
-          throw new ActionError("INTERNAL_SERVER_ERROR", t("errorNoClientSecret"));
+          throw new ActionError("INTERNAL_SERVER_ERROR", { key: "Client.Dashboard.Billing.errorNoClientSecret" });
         }
 
         return { success: true, clientSecret: setupIntent.client_secret };
       } catch (error) {
         if (error instanceof ActionError) throw error;
         console.error("startTrialSetupAction failed", error);
-        throw new ActionError("INTERNAL_SERVER_ERROR", t("errorPaymentProvider"));
+        throw new ActionError("INTERNAL_SERVER_ERROR", { key: "Client.Dashboard.Billing.errorPaymentProvider" });
       }
     }, RATE_LIMITS.BILLING);
   });
@@ -282,7 +276,6 @@ export const completeTrialAction = actionClient
   .inputSchema(completeTrialSchema)
   .action(async ({ parsedInput: { teamId, planId, interval, setupIntentId } }) => {
     return withRateLimit(async () => {
-      const t = await getTranslations("Client.Dashboard.Billing");
       await assertBillingEnabled();
 
       const session = await requireTeamPermission(teamId, TEAM_PERMISSIONS.ACCESS_BILLING);
@@ -290,7 +283,7 @@ export const completeTrialAction = actionClient
 
       const trialDays = await resolveTrialDays({ teamId, planId, userId: session.user.id });
       if (trialDays <= 0) {
-        throw new ActionError("PRECONDITION_FAILED", t("errorTrialUnavailable"));
+        throw new ActionError("PRECONDITION_FAILED", { key: "Client.Dashboard.Billing.errorTrialUnavailable" });
       }
 
       const team = await getDB().query.teamTable.findFirst({ where: { id: teamId } });
@@ -316,7 +309,7 @@ export const completeTrialAction = actionClient
         // The SetupIntent id arrives from the client: only one that succeeded for THIS
         // team's customer may start the trial.
         if (setupCustomerId !== customerId || setupIntent.status !== "succeeded" || !paymentMethodId) {
-          throw new ActionError("PRECONDITION_FAILED", t("errorTrialUnavailable"));
+          throw new ActionError("PRECONDITION_FAILED", { key: "Client.Dashboard.Billing.errorTrialUnavailable" });
         }
 
         // ...and only for the exact team/plan/interval it was stamped with in
@@ -327,7 +320,7 @@ export const completeTrialAction = actionClient
           setupMetadata.planId !== planId ||
           setupMetadata.interval !== interval
         ) {
-          throw new ActionError("PRECONDITION_FAILED", t("errorTrialUnavailable"));
+          throw new ActionError("PRECONDITION_FAILED", { key: "Client.Dashboard.Billing.errorTrialUnavailable" });
         }
 
         const subscription = await stripe.subscriptions.create({
@@ -356,7 +349,7 @@ export const completeTrialAction = actionClient
           await stripe.subscriptions.cancel(subscription.id).catch((error: unknown) => {
             console.error("completeTrialAction: losing-subscription cleanup failed", error);
           });
-          throw new ActionError("CONFLICT", t("errorStartCheckout"));
+          throw new ActionError("CONFLICT", { key: "Client.Dashboard.Billing.errorStartCheckout" });
         }
 
         // Reconciling the trialing snapshot stamps the team; stamp the acting user too.
@@ -367,7 +360,7 @@ export const completeTrialAction = actionClient
       } catch (error) {
         if (error instanceof ActionError) throw error;
         console.error("completeTrialAction failed", error);
-        throw new ActionError("INTERNAL_SERVER_ERROR", t("errorPaymentProvider"));
+        throw new ActionError("INTERNAL_SERVER_ERROR", { key: "Client.Dashboard.Billing.errorPaymentProvider" });
       }
     }, RATE_LIMITS.BILLING);
   });
@@ -376,7 +369,7 @@ export const changePlanAction = actionClient
   .inputSchema(changePlanSchema)
   .action(async ({ parsedInput: { teamId, planId, interval } }) => {
     return withRateLimit(async () => {
-      const { t, stripe, subscriptionId } = await requireExistingSubscription(teamId);
+      const { stripe, subscriptionId } = await requireExistingSubscription(teamId);
 
       try {
         const current = await stripe.subscriptions.retrieve(subscriptionId);
@@ -384,7 +377,7 @@ export const changePlanAction = actionClient
         // A past_due/incomplete/unpaid subscription must settle its open payment first;
         // otherwise the price swap piles prorations onto a team that is still locked out.
         if (!getStripeSubscriptionTransitionPolicy(current.status)?.grantsPaidAccess) {
-          throw new ActionError("PRECONDITION_FAILED", t("errorPlanChangeRequiresPaidAccess"));
+          throw new ActionError("PRECONDITION_FAILED", { key: "Client.Dashboard.Billing.errorPlanChangeRequiresPaidAccess" });
         }
 
         // Swap only the PLAN item; add-on items ride along untouched — except on a
@@ -418,7 +411,7 @@ export const changePlanAction = actionClient
       } catch (error) {
         if (error instanceof ActionError) throw error;
         console.error("changePlanAction failed", error);
-        throw new ActionError("INTERNAL_SERVER_ERROR", t("errorPaymentProvider"));
+        throw new ActionError("INTERNAL_SERVER_ERROR", { key: "Client.Dashboard.Billing.errorPaymentProvider" });
       }
     }, RATE_LIMITS.BILLING);
   });
@@ -430,14 +423,14 @@ export const updateAddonQuantityAction = actionClient
   .inputSchema(updateAddonQuantitySchema)
   .action(async ({ parsedInput: { teamId, addonId, quantity } }) => {
     return withRateLimit(async () => {
-      const { t, stripe, subscriptionId } = await requireExistingSubscription(teamId);
+      const { stripe, subscriptionId } = await requireExistingSubscription(teamId);
 
       const addon = getAddon(addonId);
       if (!addon) {
-        throw new ActionError("PRECONDITION_FAILED", t("errorAddonUnavailable"));
+        throw new ActionError("PRECONDITION_FAILED", { key: "Client.Dashboard.Billing.errorAddonUnavailable" });
       }
       if (quantity > getAddonMaxQuantity(addon)) {
-        throw new ActionError("PRECONDITION_FAILED", t("errorAddonMaxQuantity", { max: getAddonMaxQuantity(addon) }));
+        throw new ActionError("PRECONDITION_FAILED", { key: "Client.Dashboard.Billing.errorAddonMaxQuantity", params: { max: getAddonMaxQuantity(addon) } });
       }
 
       try {
@@ -446,7 +439,7 @@ export const updateAddonQuantityAction = actionClient
         // Add-ons ride on a subscription that grants paid access; a past_due/unpaid/
         // paused subscription must settle its plan payment first.
         if (!getStripeSubscriptionTransitionPolicy(current.status)?.grantsPaidAccess) {
-          throw new ActionError("PRECONDITION_FAILED", t("addonsRequirePaidPlan"));
+          throw new ActionError("PRECONDITION_FAILED", { key: "Client.Dashboard.Billing.addonsRequirePaidPlan" });
         }
 
         const classified = classifySubscriptionItems(current);
@@ -482,7 +475,7 @@ export const updateAddonQuantityAction = actionClient
       } catch (error) {
         if (error instanceof ActionError) throw error;
         console.error("updateAddonQuantityAction failed", error);
-        throw new ActionError("INTERNAL_SERVER_ERROR", t("errorPaymentProvider"));
+        throw new ActionError("INTERNAL_SERVER_ERROR", { key: "Client.Dashboard.Billing.errorPaymentProvider" });
       }
     }, RATE_LIMITS.BILLING);
   });
@@ -491,7 +484,7 @@ export const cancelSubscriptionAction = actionClient
   .inputSchema(cancelSubscriptionSchema)
   .action(async ({ parsedInput: { teamId, atPeriodEnd } }) => {
     return withRateLimit(async () => {
-      const { t, stripe, subscriptionId } = await requireExistingSubscription(teamId);
+      const { stripe, subscriptionId } = await requireExistingSubscription(teamId);
 
       try {
         const updated = atPeriodEnd
@@ -505,7 +498,7 @@ export const cancelSubscriptionAction = actionClient
       } catch (error) {
         if (error instanceof ActionError) throw error;
         console.error("cancelSubscriptionAction failed", error);
-        throw new ActionError("INTERNAL_SERVER_ERROR", t("errorPaymentProvider"));
+        throw new ActionError("INTERNAL_SERVER_ERROR", { key: "Client.Dashboard.Billing.errorPaymentProvider" });
       }
     }, RATE_LIMITS.BILLING);
   });
@@ -516,7 +509,7 @@ export const resumePaymentAction = actionClient
   .inputSchema(teamBillingSchema)
   .action(async ({ parsedInput: { teamId } }) => {
     return withRateLimit(async () => {
-      const { t, stripe, subscriptionId } = await requireExistingSubscription(teamId);
+      const { stripe, subscriptionId } = await requireExistingSubscription(teamId);
 
       const subscription = await stripe.subscriptions.retrieve(subscriptionId, {
         expand: ["latest_invoice.confirmation_secret"],
@@ -525,7 +518,7 @@ export const resumePaymentAction = actionClient
       const clientSecret = readClientSecret(subscription);
 
       if (!clientSecret) {
-        throw new ActionError("INTERNAL_SERVER_ERROR", t("errorNoClientSecret"));
+        throw new ActionError("INTERNAL_SERVER_ERROR", { key: "Client.Dashboard.Billing.errorNoClientSecret" });
       }
 
       return { success: true, clientSecret };
@@ -539,7 +532,6 @@ export const createBillingPortalSessionAction = actionClient
   .inputSchema(teamBillingSchema)
   .action(async ({ parsedInput: { teamId } }) => {
     return withRateLimit(async () => {
-      const t = await getTranslations("Client.Dashboard.Billing");
       await assertBillingEnabled();
       await requireTeamPermission(teamId, TEAM_PERMISSIONS.ACCESS_BILLING);
 
@@ -548,7 +540,7 @@ export const createBillingPortalSessionAction = actionClient
       // The portal has nothing to show until the team has a Stripe customer (created on
       // first checkout); the UI hides the button until then.
       if (!team?.stripeCustomerId) {
-        throw new ActionError("PRECONDITION_FAILED", t("errorBillingPortal"));
+        throw new ActionError("PRECONDITION_FAILED", { key: "Client.Dashboard.Billing.errorBillingPortal" });
       }
 
       try {
@@ -571,7 +563,7 @@ export const createBillingPortalSessionAction = actionClient
       } catch (error) {
         if (error instanceof ActionError) throw error;
         console.error("createBillingPortalSessionAction failed", error);
-        throw new ActionError("INTERNAL_SERVER_ERROR", t("errorPaymentProvider"));
+        throw new ActionError("INTERNAL_SERVER_ERROR", { key: "Client.Dashboard.Billing.errorPaymentProvider" });
       }
     }, RATE_LIMITS.BILLING);
   });

--- a/src/app/(dashboard)/dashboard/teams/[teamSlug]/page.tsx
+++ b/src/app/(dashboard)/dashboard/teams/[teamSlug]/page.tsx
@@ -1,11 +1,11 @@
-import type { Route } from "next";
-import { notFound, redirect } from "next/navigation";
+import { notFound } from "next/navigation";
 import { hasTeamMembership, hasTeamPermission } from "@/utils/team-auth";
-import { TEAM_PERMISSIONS } from "@/db/schema";
+import { SYSTEM_ROLES_ENUM, TEAM_PERMISSIONS } from "@/db/schema";
 import { PageHeader } from "@/components/page-header";
 import Link from "next/link";
 import { Button, buttonVariants } from "@/components/ui/button";
 import { getSessionFromCookie } from "@/utils/auth";
+import { redirectToSignIn } from "@/utils/auth-redirect";
 import { InviteMemberModal } from "@/components/teams/invite-member-modal";
 import { getTeamMembers } from "@/lib/teams/team-members";
 import { getTeamBySlug } from "@/lib/teams/teams";
@@ -22,12 +22,37 @@ import { formatDate } from "@/utils/format-date";
 import { RemoveMemberButton } from "@/components/teams/remove-member-button";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { cn } from "@/lib/utils";
-import { getTranslations } from "next-intl/server";
+import { getLocale, getTranslations } from "next-intl/server";
 
 interface TeamPageProps {
   params: Promise<{
     teamSlug: string;
   }>;
+}
+
+function getMemberRoleLabel({
+  member,
+  t,
+}: {
+  member: { roleId: string; isSystemRole: boolean; roleName: string | null };
+  t: Awaited<ReturnType<typeof getTranslations<"Client.Dashboard.Teams">>>;
+}): string {
+  if (!member.isSystemRole) {
+    return member.roleName ?? t("roleCustom");
+  }
+
+  switch (member.roleId) {
+    case SYSTEM_ROLES_ENUM.OWNER:
+      return t("roleOwner");
+    case SYSTEM_ROLES_ENUM.ADMIN:
+      return t("roleAdmin");
+    case SYSTEM_ROLES_ENUM.MEMBER:
+      return t("roleMember");
+    case SYSTEM_ROLES_ENUM.GUEST:
+      return t("roleGuest");
+    default:
+      return member.roleId;
+  }
 }
 
 // TODO Test the removal process
@@ -51,10 +76,11 @@ export async function generateMetadata({ params }: TeamPageProps) {
 export default async function TeamDashboardPage({ params }: TeamPageProps) {
   const { teamSlug } = await params;
   const t = await getTranslations("Client.Dashboard.Teams");
+  const locale = await getLocale();
 
   const session = await getSessionFromCookie();
   if (!session) {
-    return redirect("/sign-in?returnTo=" + encodeURIComponent(`/dashboard/teams/${teamSlug}`) as Route);
+    return redirectToSignIn(`/dashboard/teams/${teamSlug}`);
   }
 
   const team = await getTeamBySlug(teamSlug);
@@ -158,7 +184,7 @@ export default async function TeamDashboardPage({ params }: TeamPageProps) {
             <div className="p-6 border rounded-lg bg-card flex flex-col">
               <span className="text-sm font-medium text-muted-foreground">{t("created")}</span>
               <span className="text-2xl font-bold">
-                {new Date(team.createdAt).toLocaleDateString()}
+                {formatDate(team.createdAt, locale)}
               </span>
             </div>
           </div>
@@ -208,11 +234,11 @@ export default async function TeamDashboardPage({ params }: TeamPageProps) {
                       </TableCell>
                       <TableCell>{member.user.email}</TableCell>
                       <TableCell className="capitalize">
-                        {member.roleName}
+                        {getMemberRoleLabel({ member, t })}
                       </TableCell>
                       <TableCell>
                         {member.joinedAt !== null
-                          ? formatDate(member.joinedAt)
+                          ? formatDate(member.joinedAt, locale)
                           : t("notJoined")}
                       </TableCell>
                       <TableCell>

--- a/src/app/(dashboard)/dashboard/teams/create/page.tsx
+++ b/src/app/(dashboard)/dashboard/teams/create/page.tsx
@@ -1,5 +1,5 @@
 import { getSessionFromCookie } from "@/utils/auth";
-import { redirect } from "next/navigation";
+import { redirectToSignIn } from "@/utils/auth-redirect";
 import { CreateTeamForm } from "@/components/teams/create-team-form";
 import { PageHeader } from "@/components/page-header";
 import { getTranslations } from "next-intl/server";
@@ -19,7 +19,7 @@ export default async function CreateTeamPage() {
   const session = await getSessionFromCookie();
 
   if (!session) {
-    redirect("/sign-in?redirect=/dashboard/teams/create");
+    return redirectToSignIn("/dashboard/teams/create");
   }
 
   return (

--- a/src/app/(dashboard)/dashboard/teams/page.tsx
+++ b/src/app/(dashboard)/dashboard/teams/page.tsx
@@ -1,6 +1,7 @@
 import { getSessionFromCookie } from "@/utils/auth";
 import { getUserTeamsAction } from "@/actions/team-actions";
-import { redirect, notFound } from "next/navigation";
+import { notFound } from "next/navigation";
+import { redirectToSignIn } from "@/utils/auth-redirect";
 import Link from "next/link";
 import { buttonVariants } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
@@ -39,7 +40,7 @@ export default async function TeamsIndexPage() {
   const session = await getSessionFromCookie();
 
   if (!session) {
-    redirect("/sign-in?redirect=/dashboard/teams");
+    return redirectToSignIn("/dashboard/teams");
   }
 
   const { data: result, serverError } = await getUserTeamsAction();

--- a/src/app/(settings)/settings/[...segment]/page.tsx
+++ b/src/app/(settings)/settings/[...segment]/page.tsx
@@ -1,5 +1,5 @@
 import { getSessionFromCookie } from "@/utils/auth";
-import { redirect } from "next/navigation";
+import { redirectToSignIn } from "@/utils/auth-redirect";
 import { SettingsForm } from "../settings-form";
 import { Suspense } from "react";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
@@ -46,7 +46,7 @@ export default async function SettingsPage() {
   const session = await getSessionFromCookie();
 
   if (!session) {
-    return redirect("/sign-in");
+    return redirectToSignIn();
   }
 
   return (

--- a/src/app/(settings)/settings/language-form.tsx
+++ b/src/app/(settings)/settings/language-form.tsx
@@ -18,13 +18,13 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/utils";
-import { ENABLED_LOCALES, LOCALE_LABELS, type Locale } from "@/i18n/config";
+import { ENABLED_LOCALES, LOCALE_LABELS } from "@/i18n/config";
 import { LocaleFlag } from "@/components/locale-flag";
 import { useChangeLocale } from "@/hooks/useChangeLocale";
 
 export function LanguageForm() {
   const t = useTranslations("Client.Settings.Language");
-  const activeLocale = useLocale() as Locale;
+  const activeLocale = useLocale();
   const { changeLocale, isPending } = useChangeLocale();
 
   // Nothing to switch between when i18n is disabled (single active locale).

--- a/src/app/(settings)/settings/layout.tsx
+++ b/src/app/(settings)/settings/layout.tsx
@@ -1,6 +1,6 @@
 import { getSessionFromCookie } from "@/utils/auth";
 import { isBillingEnabled } from "@/flags";
-import { redirect } from "next/navigation";
+import { redirectToSignIn } from "@/utils/auth-redirect";
 import { AppSidebar } from "@/components/app-sidebar";
 import { SessionHydrator } from "@/components/session-hydrator";
 import { Separator } from "@/components/ui/separator";
@@ -20,7 +20,7 @@ export default async function SettingsLayout({
   const session = await getSessionFromCookie();
 
   if (!session) {
-    return redirect("/sign-in");
+    return redirectToSignIn();
   }
 
   return (

--- a/src/app/(settings)/settings/page.tsx
+++ b/src/app/(settings)/settings/page.tsx
@@ -1,5 +1,5 @@
 import { getSessionFromCookie } from "@/utils/auth";
-import { redirect } from "next/navigation";
+import { redirectToSignIn } from "@/utils/auth-redirect";
 import { SettingsForm } from "./settings-form";
 import { LanguageForm } from "./language-form";
 import { Suspense } from "react";
@@ -47,7 +47,7 @@ export default async function SettingsPage() {
   const session = await getSessionFromCookie();
 
   if (!session) {
-    return redirect("/sign-in");
+    return redirectToSignIn();
   }
 
   return (

--- a/src/app/(settings)/settings/security/page.tsx
+++ b/src/app/(settings)/settings/security/page.tsx
@@ -1,7 +1,7 @@
 import "server-only";
 
 import { getSessionFromCookie } from "@/utils/auth";
-import { redirect } from "next/navigation";
+import { redirectToSignIn } from "@/utils/auth-redirect";
 import { getDB } from "@/db";
 import { passKeyCredentialTable } from "@/db/schema";
 import { eq } from "drizzle-orm";
@@ -19,7 +19,7 @@ export default async function SecurityPage() {
   const session = await getSessionFromCookie();
 
   if (!session) {
-    return redirect("/sign-in");
+    return redirectToSignIn();
   }
 
   const db = getDB();

--- a/src/app/(settings)/settings/security/passkey-settings.actions.ts
+++ b/src/app/(settings)/settings/security/passkey-settings.actions.ts
@@ -19,7 +19,6 @@ import { withRateLimit, RATE_LIMITS } from "@/utils/with-rate-limit";
 import isProd from "@/utils/is-prod";
 import ms from "ms";
 import { emailString, v, validationKey } from "@/lib/validation";
-import { getTranslations } from "next-intl/server";
 
 const generateRegistrationOptionsSchema = v.object({
   email: emailString(),
@@ -33,8 +32,6 @@ export const generateRegistrationOptionsAction = actionClient
   .inputSchema(generateRegistrationOptionsSchema)
   .action(async ({ parsedInput: input }) => {
     return withRateLimit(async () => {
-      const t = await getTranslations("Client.Settings.Security");
-      const tErrors = await getTranslations("Client.Errors");
       const session = await requireVerifiedEmail();
 
       const db = getDB();
@@ -43,12 +40,12 @@ export const generateRegistrationOptionsAction = actionClient
       });
 
       if (!user) {
-        throw new ActionError("NOT_FOUND", tErrors("userNotFound"));
+        throw new ActionError("NOT_FOUND", { key: "Client.Errors.userNotFound" });
       }
 
       // Verify the email matches the logged-in user
       if (user.id !== session?.user?.id) {
-        throw new ActionError("FORBIDDEN", t("errorRegisterOwnAccount"));
+        throw new ActionError("FORBIDDEN", { key: "Client.Settings.Security.errorRegisterOwnAccount" });
       }
 
       const existingPasskeys = await db
@@ -57,10 +54,7 @@ export const generateRegistrationOptionsAction = actionClient
         .where(eq(passKeyCredentialTable.userId, user.id));
 
       if (existingPasskeys.length >= 5) {
-        throw new ActionError(
-          "FORBIDDEN",
-          t("errorPasskeyLimit", { limit: 5 })
-        );
+        throw new ActionError("FORBIDDEN", { key: "Client.Settings.Security.errorPasskeyLimit", params: { limit: 5 } });
       }
 
       const options = await generatePasskeyRegistrationOptions(user.id, input.email);
@@ -87,8 +81,6 @@ export const verifyRegistrationAction = actionClient
   .inputSchema(verifyRegistrationSchema)
   .action(async ({ parsedInput: input }) => {
     return withRateLimit(async () => {
-      const t = await getTranslations("Client.Settings.Security");
-      const tErrors = await getTranslations("Client.Errors");
       const session = await requireVerifiedEmail();
 
       const db = getDB();
@@ -97,19 +89,19 @@ export const verifyRegistrationAction = actionClient
       });
 
       if (!user) {
-        throw new ActionError("NOT_FOUND", tErrors("userNotFound"));
+        throw new ActionError("NOT_FOUND", { key: "Client.Errors.userNotFound" });
       }
 
       // Verify the email matches the logged-in user
       if (user.id !== session?.user?.id) {
-        throw new ActionError("FORBIDDEN", t("errorRegisterOwnAccount"));
+        throw new ActionError("FORBIDDEN", { key: "Client.Settings.Security.errorRegisterOwnAccount" });
       }
 
       const cookieStore = await cookies();
       const challenge = cookieStore.get(PASSKEY_REGISTRATION_CHALLENGE_COOKIE_NAME)?.value;
 
       if (!challenge) {
-        throw new ActionError("PRECONDITION_FAILED", t("errorInvalidRegistrationSession"));
+        throw new ActionError("PRECONDITION_FAILED", { key: "Client.Settings.Security.errorInvalidRegistrationSession" });
       }
 
       try {
@@ -127,7 +119,7 @@ export const verifyRegistrationAction = actionClient
           throw error;
         }
 
-        throw new ActionError("PRECONDITION_FAILED", t("errorRegisterFailed"));
+        throw new ActionError("PRECONDITION_FAILED", { key: "Client.Settings.Security.errorRegisterFailed" });
       } finally {
         cookieStore.delete(PASSKEY_REGISTRATION_CHALLENGE_COOKIE_NAME);
       }
@@ -142,21 +134,16 @@ export const deletePasskeyAction = actionClient
   .inputSchema(deletePasskeySchema)
   .action(async ({ parsedInput: input }) => {
     return withRateLimit(async () => {
-      const t = await getTranslations("Client.Settings.Security");
-      const tErrors = await getTranslations("Client.Errors");
       const session = await requireVerifiedEmail();
       const userId = session?.user?.id;
 
       if (!userId) {
-        throw new ActionError("NOT_AUTHORIZED", tErrors("notAuthenticated"));
+        throw new ActionError("NOT_AUTHORIZED", { key: "Client.Errors.notAuthenticated" });
       }
 
       // Prevent deletion of the current passkey
       if (session?.passkeyCredentialId === input.credentialId) {
-        throw new ActionError(
-          "FORBIDDEN",
-          t("errorDeleteCurrentPasskey")
-        );
+        throw new ActionError("FORBIDDEN", { key: "Client.Settings.Security.errorDeleteCurrentPasskey" });
       }
 
       const db = getDB();
@@ -169,7 +156,7 @@ export const deletePasskeyAction = actionClient
       });
 
       if (!passkey) {
-        throw new ActionError("NOT_FOUND", t("errorPasskeyNotFound"));
+        throw new ActionError("NOT_FOUND", { key: "Client.Settings.Security.errorPasskeyNotFound" });
       }
 
       const passkeys = await db
@@ -182,14 +169,11 @@ export const deletePasskeyAction = actionClient
       });
 
       if (!user) {
-        throw new ActionError("NOT_FOUND", tErrors("userNotFound"));
+        throw new ActionError("NOT_FOUND", { key: "Client.Errors.userNotFound" });
       }
 
       if (passkeys.length === 1 && !user.passwordHash) {
-        throw new ActionError(
-          "FORBIDDEN",
-          t("errorDeleteLastPasskey")
-        );
+        throw new ActionError("FORBIDDEN", { key: "Client.Settings.Security.errorDeleteLastPasskey" });
       }
 
       await db
@@ -232,12 +216,11 @@ export const verifyAuthenticationAction = actionClient
   .inputSchema(verifyAuthenticationSchema)
   .action(async ({ parsedInput: input }) => {
     return withRateLimit(async () => {
-      const t = await getTranslations("Client.Settings.Security");
       const cookieStore = await cookies();
       const challenge = cookieStore.get(PASSKEY_AUTHENTICATION_CHALLENGE_COOKIE_NAME)?.value;
 
       if (!challenge) {
-        throw new ActionError("PRECONDITION_FAILED", t("errorInvalidAuthSession"));
+        throw new ActionError("PRECONDITION_FAILED", { key: "Client.Settings.Security.errorInvalidAuthSession" });
       }
 
       try {
@@ -247,7 +230,7 @@ export const verifyAuthenticationAction = actionClient
         });
 
         if (!verification.verified) {
-          throw new ActionError("FORBIDDEN", t("errorAuthFailed"));
+          throw new ActionError("FORBIDDEN", { key: "Client.Settings.Security.errorAuthFailed" });
         }
 
         await createAndStoreSession(credential.userId, "passkey", input.response.id);
@@ -257,7 +240,7 @@ export const verifyAuthenticationAction = actionClient
           throw error;
         }
 
-        throw new ActionError("FORBIDDEN", t("errorAuthFailed"));
+        throw new ActionError("FORBIDDEN", { key: "Client.Settings.Security.errorAuthFailed" });
       } finally {
         cookieStore.delete(PASSKEY_AUTHENTICATION_CHALLENGE_COOKIE_NAME);
       }

--- a/src/app/(settings)/settings/security/passkey.client.tsx
+++ b/src/app/(settings)/settings/security/passkey.client.tsx
@@ -17,7 +17,7 @@ import { useRouter } from "next/navigation";
 import { useAction } from "next-safe-action/hooks";
 import { PASSKEY_AUTHENTICATOR_IDS } from "@/utils/passkey-authenticator-ids";
 import { cn } from "@/lib/utils";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import type { ParsedUserAgent } from "@/types";
 
 interface PasskeyRegistrationButtonProps {
@@ -96,6 +96,7 @@ interface PasskeysListProps {
 
 export function PasskeysList({ passkeys, currentPasskeyId, email }: PasskeysListProps) {
   const router = useRouter();
+  const locale = useLocale();
   const dialogCloseRef = useRef<HTMLButtonElement>(null);
   const t = useTranslations("Client.Settings.Security");
   const { execute: deletePasskey } = useAction(deletePasskeyAction, {
@@ -141,7 +142,7 @@ export function PasskeysList({ passkeys, currentPasskeyId, email }: PasskeysList
                       {isCurrentPasskey(passkey) && <Badge>{t("currentPasskeyBadge")}</Badge>}
                     </CardTitle>
                     <div className="text-sm text-muted-foreground whitespace-nowrap">
-                      · {formatRelativeDateTime(passkey.createdAt)}
+                      · {formatRelativeDateTime(passkey.createdAt, locale)}
                     </div>
                   </div>
                   {passkey.parsedUserAgent && (

--- a/src/app/(settings)/settings/sessions/page.tsx
+++ b/src/app/(settings)/settings/sessions/page.tsx
@@ -2,7 +2,7 @@ import { Suspense } from "react";
 import { SessionsClient } from "./sessions.client";
 import { Skeleton } from "@/components/ui/skeleton";
 import { getSessionsAction } from "./sessions.actions";
-import { redirect } from "next/navigation";
+import { redirectToSignIn } from "@/utils/auth-redirect";
 import { getTranslations } from "next-intl/server";
 
 export async function generateMetadata() {
@@ -17,7 +17,7 @@ export default async function SessionsPage() {
   const { data: sessions, serverError } = await getSessionsAction()
 
   if (serverError || !sessions) {
-    return redirect("/sign-in")
+    return redirectToSignIn()
   }
 
   return (

--- a/src/app/(settings)/settings/sessions/sessions.actions.ts
+++ b/src/app/(settings)/settings/sessions/sessions.actions.ts
@@ -8,7 +8,6 @@ import { withRateLimit, RATE_LIMITS } from "@/utils/with-rate-limit";
 import { UAParser } from 'ua-parser-js';
 import { SessionWithMeta } from "@/types";
 import { v } from "@/lib/validation";
-import { getTranslations } from "next-intl/server";
 
 function isValidSession(session: unknown): session is SessionWithMeta {
   if (!session || typeof session !== 'object') return false;
@@ -21,11 +20,10 @@ export const getSessionsAction = actionClient
   .action(async () => {
     return withRateLimit(
       async () => {
-        const t = await getTranslations("Client.Settings.Sessions");
         const session = await getSessionFromCookie();
 
         if (!session?.user?.id) {
-          throw new ActionError("NOT_AUTHORIZED", t("errorUnauthorized"));
+          throw new ActionError("NOT_AUTHORIZED", { key: "Client.Settings.Sessions.errorUnauthorized" });
         }
 
         const sessionIds = await getAllSessionIdsOfUser(session.user.id);
@@ -83,14 +81,10 @@ export const deleteSessionAction = actionClient
   .action(async ({ parsedInput: input }) => {
     return withRateLimit(
       async () => {
-        const tErrors = await getTranslations("Client.Errors");
         const session = await getSessionFromCookie();
 
         if (!session) {
-          throw new ActionError(
-            "NOT_AUTHORIZED",
-            tErrors("notAuthenticated")
-          );
+          throw new ActionError("NOT_AUTHORIZED", { key: "Client.Errors.notAuthenticated" });
         }
 
         await deleteKVSession(input.sessionId, session.user.id);

--- a/src/app/(settings)/settings/sessions/sessions.client.tsx
+++ b/src/app/(settings)/settings/sessions/sessions.client.tsx
@@ -26,14 +26,33 @@ import React from "react";
 import { useRouter } from "next/navigation";
 import { cn } from "@/lib/utils";
 import type { SessionWithMeta } from "@/types";
-import { capitalize } from 'remeda'
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 
+function getAuthMethodLabel({
+  authenticationType,
+  t,
+}: {
+  authenticationType: NonNullable<SessionWithMeta["authenticationType"]>;
+  t: ReturnType<typeof useTranslations<"Client.Settings.Sessions">>;
+}): string {
+  switch (authenticationType) {
+    case "password":
+      return t("authMethodPassword");
+    case "passkey":
+      return t("authMethodPasskey");
+    case "google-oauth":
+      return t("authMethodGoogleOauth");
+  }
+}
 
-const regionNames = new Intl.DisplayNames(['en'], { type: 'region' });
 
 export function SessionsClient({ sessions }: { sessions: SessionWithMeta[] }) {
   const router = useRouter();
+  const locale = useLocale();
+  const regionNames = React.useMemo(
+    () => new Intl.DisplayNames([locale], { type: "region" }),
+    [locale],
+  );
   const dialogCloseRef = React.useRef<HTMLButtonElement>(null);
   const t = useTranslations("Client.Settings.Sessions");
   const { execute: deleteSession } = useAction(deleteSessionAction, {
@@ -63,11 +82,16 @@ export function SessionsClient({ sessions }: { sessions: SessionWithMeta[] }) {
                   </CardTitle>
                   {session?.authenticationType && (
                     <Badge variant='outline'>
-                      {t("authenticatedWith", { method: capitalize(session?.authenticationType ?? "password")?.replace("-", " ") })}
+                      {t("authenticatedWith", {
+                        method: getAuthMethodLabel({
+                          authenticationType: session.authenticationType,
+                          t,
+                        }),
+                      })}
                     </Badge>
                   )}
                   <div className="text-sm text-muted-foreground whitespace-nowrap">
-                    &nbsp;· &nbsp;{formatRelativeDateTime(session.createdAt)}
+                    &nbsp;· &nbsp;{formatRelativeDateTime(session.createdAt, locale)}
                   </div>
                 </div>
                 <CardDescription className="text-sm">

--- a/src/app/(settings)/settings/settings-nav.tsx
+++ b/src/app/(settings)/settings/settings-nav.tsx
@@ -2,6 +2,7 @@
 
 import type { Route } from 'next'
 import Link from "next/link";
+import { Link as LocaleLink } from "@/i18n/navigation";
 import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -37,6 +38,9 @@ interface SettingsNavItem {
   titleKey: SettingsNavKey;
   href: Route;
   icon: React.ComponentType<{ className?: string }>;
+  // True for destinations under `app/[locale]` (e.g. /forgot-password), which
+  // need the locale-prefixing Link; /settings/* routes are unprefixed.
+  isLocalizedRoute?: boolean;
 }
 
 const settingsNavItems: SettingsNavItem[] = [
@@ -59,6 +63,7 @@ const settingsNavItems: SettingsNavItem[] = [
     titleKey: "changePassword",
     href: "/forgot-password",
     icon: Lock,
+    isLocalizedRoute: true,
   },
 ];
 
@@ -77,7 +82,11 @@ export function SettingsNav() {
             key={item.href}
             value={item.href}
             nativeButton={false}
-            render={<Link href={item.href} className="flex items-center gap-2" />}
+            render={
+              item.isLocalizedRoute
+                ? <LocaleLink href={item.href} className="flex items-center gap-2" />
+                : <Link href={item.href} className="flex items-center gap-2" />
+            }
           >
               <item.icon className="h-4 w-4" />
               {t(item.titleKey)}

--- a/src/app/(settings)/settings/settings.actions.ts
+++ b/src/app/(settings)/settings/settings.actions.ts
@@ -10,19 +10,17 @@ import { revalidatePath } from "next/cache";
 import { userSettingsSchema } from "@/schemas/settings.schema";
 import { updateAllSessionsOfUser } from "@/utils/kv-session";
 import { withRateLimit, RATE_LIMITS } from "@/utils/with-rate-limit";
-import { getTranslations } from "next-intl/server";
 
 export const updateUserProfileAction = actionClient
   .inputSchema(userSettingsSchema)
   .action(async ({ parsedInput: input }) => {
     return withRateLimit(
       async () => {
-        const t = await getTranslations("Client.Settings.Profile");
         const session = await requireVerifiedEmail();
         const db = getDB();
 
         if (!session?.user?.id) {
-          throw new ActionError("NOT_AUTHORIZED", t("errorUnauthorized"));
+          throw new ActionError("NOT_AUTHORIZED", { key: "Client.Settings.Profile.errorUnauthorized" });
         }
 
         try {
@@ -38,10 +36,7 @@ export const updateUserProfileAction = actionClient
           return { success: true };
         } catch (error) {
           console.error(error)
-          throw new ActionError(
-            "INTERNAL_SERVER_ERROR",
-            t("errorUpdateFailed")
-          );
+          throw new ActionError("INTERNAL_SERVER_ERROR", { key: "Client.Settings.Profile.errorUpdateFailed" });
         }
       },
       RATE_LIMITS.SETTINGS

--- a/src/app/[locale]/(auth)/forgot-password/forgot-password.action.ts
+++ b/src/app/[locale]/(auth)/forgot-password/forgot-password.action.ts
@@ -1,6 +1,5 @@
 "use server";
 
-import { getTranslations } from "next-intl/server";
 import { ActionError } from "@/lib/action-error";
 import { actionClient } from "@/lib/safe-action";
 import { getDB } from "@/db";
@@ -24,23 +23,15 @@ export const forgotPasswordAction = actionClient
   .action(async ({ parsedInput: input }) => {
     return withRateLimit(
       async () => {
-        const tCommon = await getTranslations("Client.Auth.Common");
-        const tErrors = await getTranslations("Client.Errors");
         if (await isTurnstileEnabled()) {
           if (!input.captchaToken) {
-            throw new ActionError(
-              "INPUT_PARSE_ERROR",
-              tCommon("errorCaptcha")
-            )
+            throw new ActionError("INPUT_PARSE_ERROR", { key: "Client.Auth.Common.errorCaptcha" })
           }
 
           const success = await validateTurnstileToken(input.captchaToken)
 
           if (!success) {
-            throw new ActionError(
-              "INPUT_PARSE_ERROR",
-              tCommon("errorCaptcha")
-            )
+            throw new ActionError("INPUT_PARSE_ERROR", { key: "Client.Auth.Common.errorCaptcha" })
           }
         }
 
@@ -89,10 +80,7 @@ export const forgotPasswordAction = actionClient
             throw error;
           }
 
-          throw new ActionError(
-            "INTERNAL_SERVER_ERROR",
-            tErrors("unexpected")
-          );
+          throw new ActionError("INTERNAL_SERVER_ERROR", { key: "Client.Errors.unexpected" });
         }
       },
       RATE_LIMITS.FORGOT_PASSWORD

--- a/src/app/[locale]/(auth)/forgot-password/forgot-password.client.tsx
+++ b/src/app/[locale]/(auth)/forgot-password/forgot-password.client.tsx
@@ -11,6 +11,7 @@ import {
 import { AuthStatusCard } from "@/app/[locale]/(auth)/_components/auth-status-card";
 import { Input } from "@/components/ui/input";
 import { useRouter } from "next/navigation";
+import { useRouter as useLocaleRouter } from "@/i18n/navigation";
 import { forgotPasswordAction } from "./forgot-password.action";
 import { useAction } from "next-safe-action/hooks";
 import { toast } from "sonner";
@@ -30,6 +31,9 @@ type ForgotPasswordSchema = v.InferOutput<typeof forgotPasswordSchema>;
 export default function ForgotPasswordClientComponent() {
   const { session } = useSessionStore()
   const { isTurnstileEnabled } = usePublicAuthFeatureState()
+  // `localeRouter` keeps the locale prefix for `[locale]` routes; plain `router`
+  // targets unprefixed authed routes like `/settings`.
+  const localeRouter = useLocaleRouter();
   const router = useRouter();
   const t = useTranslations("Client.Auth.ForgotPassword");
   const tCommon = useTranslations("Client.Auth.Common");
@@ -73,7 +77,7 @@ export default function ForgotPasswordClientComponent() {
         title={t("checkEmailTitle")}
         description={t("checkEmailDescription")}
         actionLabel={tCommon("backToLogin")}
-        onAction={() => router.push("/sign-in")}
+        onAction={() => localeRouter.push("/sign-in")}
       />
     );
   }
@@ -104,7 +108,7 @@ export default function ForgotPasswordClientComponent() {
                       <Input
                         type="email"
                         className="w-full px-3 py-2"
-                        placeholder="name@example.com"
+                        placeholder={tCommon("emailPlaceholder")}
                         {...field}
                       />
                     </FormControl>
@@ -146,7 +150,7 @@ export default function ForgotPasswordClientComponent() {
             type="button"
             variant="link"
             className="w-full"
-            onClick={() => router.push("/sign-in")}
+            onClick={() => localeRouter.push("/sign-in")}
           >
             {tCommon("backToLogin")}
           </Button>

--- a/src/app/[locale]/(auth)/reset-password/reset-password.action.ts
+++ b/src/app/[locale]/(auth)/reset-password/reset-password.action.ts
@@ -1,6 +1,5 @@
 "use server";
 
-import { getTranslations } from "next-intl/server";
 import { ActionError } from "@/lib/action-error";
 import { actionClient } from "@/lib/safe-action";
 import { getDB } from "@/db";
@@ -17,8 +16,6 @@ export const resetPasswordAction = actionClient
   .action(async ({ parsedInput: input }) => {
     return withRateLimit(
       async () => {
-        const t = await getTranslations("Client.Auth.ResetPassword");
-        const tErrors = await getTranslations("Client.Errors");
         const db = getDB();
 
         try {
@@ -27,11 +24,11 @@ export const resetPasswordAction = actionClient
             key: getResetTokenKey,
             notFoundError: {
               code: "NOT_FOUND",
-              message: t("errorInvalidToken"),
+              message: { key: "Client.Auth.ResetPassword.errorInvalidToken" },
             },
             expiredError: {
               code: "PRECONDITION_FAILED",
-              message: t("errorTokenExpired"),
+              message: { key: "Client.Auth.ResetPassword.errorTokenExpired" },
             },
           });
 
@@ -41,10 +38,7 @@ export const resetPasswordAction = actionClient
           });
 
           if (!user) {
-            throw new ActionError(
-              "NOT_FOUND",
-              tErrors("userNotFound")
-            );
+            throw new ActionError("NOT_FOUND", { key: "Client.Errors.userNotFound" });
           }
 
           const passwordHash = await hashPassword({ password: input.password });
@@ -66,10 +60,7 @@ export const resetPasswordAction = actionClient
             throw error;
           }
 
-          throw new ActionError(
-            "INTERNAL_SERVER_ERROR",
-            tErrors("unexpected")
-          );
+          throw new ActionError("INTERNAL_SERVER_ERROR", { key: "Client.Errors.unexpected" });
         }
       },
       RATE_LIMITS.RESET_PASSWORD

--- a/src/app/[locale]/(auth)/reset-password/reset-password.client.tsx
+++ b/src/app/[locale]/(auth)/reset-password/reset-password.client.tsx
@@ -9,7 +9,8 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { AuthStatusCard } from "@/app/[locale]/(auth)/_components/auth-status-card";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useSearchParams } from "next/navigation";
+import { useRouter } from "@/i18n/navigation";
 import { resetPasswordAction } from "./reset-password.action";
 import { useAction } from "next-safe-action/hooks";
 import { toast } from "sonner";

--- a/src/app/[locale]/(auth)/send-verification.action.ts
+++ b/src/app/[locale]/(auth)/send-verification.action.ts
@@ -1,6 +1,5 @@
 "use server";
 
-import { getTranslations } from "next-intl/server";
 import { ActionError } from "@/lib/action-error";
 import { actionClient } from "@/lib/safe-action";
 import { getSessionFromCookie } from "@/utils/auth";
@@ -13,22 +12,14 @@ export const sendVerificationAction = actionClient
   .action(async () => {
     return withRateLimit(
       async () => {
-        const t = await getTranslations("Client.Auth.Common");
-        const tErrors = await getTranslations("Client.Errors");
         const session = await getSessionFromCookie();
 
         if (!session) {
-          throw new ActionError(
-            "NOT_AUTHORIZED",
-            tErrors("notAuthenticated")
-          );
+          throw new ActionError("NOT_AUTHORIZED", { key: "Client.Errors.notAuthenticated" });
         }
 
         if (session?.user?.emailVerified) {
-          throw new ActionError(
-            "PRECONDITION_FAILED",
-            t("errorEmailAlreadyVerified")
-          );
+          throw new ActionError("PRECONDITION_FAILED", { key: "Client.Auth.Common.errorEmailAlreadyVerified" });
         }
 
         await sendUserVerificationEmail({

--- a/src/app/[locale]/(auth)/sign-in/sign-in-auth.ts
+++ b/src/app/[locale]/(auth)/sign-in/sign-in-auth.ts
@@ -1,6 +1,5 @@
 import "server-only";
 
-import { getTranslations } from "next-intl/server";
 import { ActionError } from "@/lib/action-error";
 import { getDB } from "@/db";
 import { verifyPassword } from "@/utils/password-hasher";
@@ -18,8 +17,6 @@ export async function signInWithPassword({
 }: SignInWithPasswordParams): Promise<{ success: true }> {
   return withRateLimit(
     async () => {
-      const t = await getTranslations("Client.Auth.SignIn");
-      const tErrors = await getTranslations("Client.Errors");
       const db = getDB();
 
       try {
@@ -28,24 +25,15 @@ export async function signInWithPassword({
         });
 
         if (!user) {
-          throw new ActionError(
-            "NOT_AUTHORIZED",
-            t("errorInvalidCredentials")
-          );
+          throw new ActionError("NOT_AUTHORIZED", { key: "Client.Auth.SignIn.errorInvalidCredentials" });
         }
 
         if (!user.passwordHash && user.googleAccountId) {
-          throw new ActionError(
-            "FORBIDDEN",
-            t("errorUseGoogle")
-          );
+          throw new ActionError("FORBIDDEN", { key: "Client.Auth.SignIn.errorUseGoogle" });
         }
 
         if (!user.passwordHash) {
-          throw new ActionError(
-            "NOT_AUTHORIZED",
-            t("errorInvalidCredentials")
-          );
+          throw new ActionError("NOT_AUTHORIZED", { key: "Client.Auth.SignIn.errorInvalidCredentials" });
         }
 
         const isValid = await verifyPassword({
@@ -54,10 +42,7 @@ export async function signInWithPassword({
         });
 
         if (!isValid) {
-          throw new ActionError(
-            "NOT_AUTHORIZED",
-            t("errorInvalidCredentials")
-          );
+          throw new ActionError("NOT_AUTHORIZED", { key: "Client.Auth.SignIn.errorInvalidCredentials" });
         }
 
         const passkey = await db.query.passKeyCredentialTable.findFirst({
@@ -68,10 +53,7 @@ export async function signInWithPassword({
         });
 
         if (passkey) {
-          throw new ActionError(
-            "FORBIDDEN",
-            t("errorUsePasskey")
-          );
+          throw new ActionError("FORBIDDEN", { key: "Client.Auth.SignIn.errorUsePasskey" });
         }
 
         await createAndStoreSession(user.id, "password");
@@ -84,10 +66,7 @@ export async function signInWithPassword({
           throw error;
         }
 
-        throw new ActionError(
-          "INTERNAL_SERVER_ERROR",
-          tErrors("unexpected")
-        );
+        throw new ActionError("INTERNAL_SERVER_ERROR", { key: "Client.Errors.unexpected" });
       }
     },
     RATE_LIMITS.SIGN_IN

--- a/src/app/[locale]/(auth)/sign-up/passkey-sign-up.actions.ts
+++ b/src/app/[locale]/(auth)/sign-up/passkey-sign-up.actions.ts
@@ -1,6 +1,5 @@
 "use server";
 
-import { getTranslations } from "next-intl/server";
 import { ActionError } from "@/lib/action-error";
 import { actionClient } from "@/lib/safe-action";
 import { generatePasskeyRegistrationOptions, verifyPasskeyRegistration } from "@/utils/webauthn";
@@ -26,24 +25,16 @@ export const startPasskeyRegistrationAction = actionClient
   .action(async ({ parsedInput: input }) => {
     return withRateLimit(
       async () => {
-        const t = await getTranslations("Client.Auth.SignUp");
-        const tCommon = await getTranslations("Client.Auth.Common");
 
         if (await isTurnstileEnabled()) {
           if (!input.captchaToken) {
-            throw new ActionError(
-              "INPUT_PARSE_ERROR",
-              tCommon("errorCaptcha")
-            )
+            throw new ActionError("INPUT_PARSE_ERROR", { key: "Client.Auth.Common.errorCaptcha" })
           }
 
           const success = await validateTurnstileToken(input.captchaToken)
 
           if (!success) {
-            throw new ActionError(
-              "INPUT_PARSE_ERROR",
-              tCommon("errorCaptcha")
-            )
+            throw new ActionError("INPUT_PARSE_ERROR", { key: "Client.Auth.Common.errorCaptcha" })
           }
         }
 
@@ -56,10 +47,7 @@ export const startPasskeyRegistrationAction = actionClient
         });
 
         if (existingUser) {
-          throw new ActionError(
-            "CONFLICT",
-            t("errorAccountExists")
-          );
+          throw new ActionError("CONFLICT", { key: "Client.Auth.SignUp.errorAccountExists" });
         }
 
         const ipAddress = await getIP();
@@ -74,10 +62,7 @@ export const startPasskeyRegistrationAction = actionClient
           .returning();
 
         if (!user) {
-          throw new ActionError(
-            "INTERNAL_SERVER_ERROR",
-            tCommon("errorCreateUser")
-          );
+          throw new ActionError("INTERNAL_SERVER_ERROR", { key: "Client.Auth.Common.errorCreateUser" });
         }
 
         const options = await generatePasskeyRegistrationOptions(user.id, input.email);
@@ -130,17 +115,12 @@ const completePasskeyRegistrationSchema = v.object({
 export const completePasskeyRegistrationAction = actionClient
   .inputSchema(completePasskeyRegistrationSchema)
   .action(async ({ parsedInput: input }) => {
-    const t = await getTranslations("Client.Auth.SignUp");
-    const tErrors = await getTranslations("Client.Errors");
     const cookieStore = await cookies();
     const challenge = cookieStore.get(PASSKEY_CHALLENGE_COOKIE_NAME)?.value;
     const userId = cookieStore.get(PASSKEY_USER_ID_COOKIE_NAME)?.value;
 
     if (!challenge || !userId) {
-      throw new ActionError(
-        "PRECONDITION_FAILED",
-        t("errorInvalidRegistrationSession")
-      );
+      throw new ActionError("PRECONDITION_FAILED", { key: "Client.Auth.SignUp.errorInvalidRegistrationSession" });
     }
 
     try {
@@ -159,10 +139,7 @@ export const completePasskeyRegistrationAction = actionClient
       });
 
       if (!user || !user.email) {
-        throw new ActionError(
-          "INTERNAL_SERVER_ERROR",
-          tErrors("userNotFound")
-        );
+        throw new ActionError("INTERNAL_SERVER_ERROR", { key: "Client.Errors.userNotFound" });
       }
 
       await sendUserVerificationEmail({
@@ -180,9 +157,6 @@ export const completePasskeyRegistrationAction = actionClient
       return { success: true };
     } catch (error) {
       console.error("Failed to register passkey:", error);
-      throw new ActionError(
-        "PRECONDITION_FAILED",
-        t("errorRegisterFailed")
-      );
+      throw new ActionError("PRECONDITION_FAILED", { key: "Client.Auth.SignUp.errorRegisterFailed" });
     }
   });

--- a/src/app/[locale]/(auth)/sign-up/sign-up.actions.ts
+++ b/src/app/[locale]/(auth)/sign-up/sign-up.actions.ts
@@ -1,6 +1,5 @@
 "use server";
 
-import { getTranslations } from "next-intl/server";
 import { ActionError } from "@/lib/action-error";
 import { actionClient } from "@/lib/safe-action";
 import { getDB } from "@/db"
@@ -19,25 +18,17 @@ export const signUpAction = actionClient
   .action(async ({ parsedInput: input }) => {
     return withRateLimit(
       async () => {
-        const t = await getTranslations("Client.Auth.SignUp");
-        const tCommon = await getTranslations("Client.Auth.Common");
         const db = getDB();
 
         if (await isTurnstileEnabled()) {
           if (!input.captchaToken) {
-            throw new ActionError(
-              "INPUT_PARSE_ERROR",
-              tCommon("errorCaptcha")
-            )
+            throw new ActionError("INPUT_PARSE_ERROR", { key: "Client.Auth.Common.errorCaptcha" })
           }
 
           const success = await validateTurnstileToken(input.captchaToken)
 
           if (!success) {
-            throw new ActionError(
-              "INPUT_PARSE_ERROR",
-              tCommon("errorCaptcha")
-            )
+            throw new ActionError("INPUT_PARSE_ERROR", { key: "Client.Auth.Common.errorCaptcha" })
           }
         }
 
@@ -48,10 +39,7 @@ export const signUpAction = actionClient
         });
 
         if (existingUser) {
-          throw new ActionError(
-            "CONFLICT",
-            t("errorEmailTaken")
-          );
+          throw new ActionError("CONFLICT", { key: "Client.Auth.SignUp.errorEmailTaken" });
         }
 
         // Hash the password
@@ -69,10 +57,7 @@ export const signUpAction = actionClient
           .returning();
 
         if (!user || !user.email) {
-          throw new ActionError(
-            "INTERNAL_SERVER_ERROR",
-            tCommon("errorCreateUser")
-          );
+          throw new ActionError("INTERNAL_SERVER_ERROR", { key: "Client.Auth.Common.errorCreateUser" });
         }
 
         try {
@@ -86,10 +71,7 @@ export const signUpAction = actionClient
         } catch (error) {
           console.error(error)
 
-          throw new ActionError(
-            "INTERNAL_SERVER_ERROR",
-            t("errorCreateSession")
-          );
+          throw new ActionError("INTERNAL_SERVER_ERROR", { key: "Client.Auth.SignUp.errorCreateSession" });
         }
 
         return { success: true };

--- a/src/app/[locale]/(auth)/sso/google/callback/google-callback.action.ts
+++ b/src/app/[locale]/(auth)/sso/google/callback/google-callback.action.ts
@@ -1,6 +1,5 @@
 "use server";
 
-import { getTranslations } from "next-intl/server";
 import { ActionError } from "@/lib/action-error";
 import { actionClient } from "@/lib/safe-action";
 import { googleSSOCallbackSchema } from "@/schemas/google-sso-callback.schema";
@@ -42,14 +41,9 @@ export const googleSSOCallbackAction = actionClient
   .inputSchema(googleSSOCallbackSchema)
   .action(async ({ parsedInput: input }) => {
     return withRateLimit(async () => {
-      const t = await getTranslations("Client.Auth.GoogleCallback");
-      const tErrors = await getTranslations("Client.Errors");
 
       if (!(await isGoogleSSOEnabled())) {
-        throw new ActionError(
-          "FORBIDDEN",
-          t("errorNotEnabled")
-        );
+        throw new ActionError("FORBIDDEN", { key: "Client.Auth.GoogleCallback.errorNotEnabled" });
       }
 
       const cookieStore = await cookies();
@@ -57,17 +51,11 @@ export const googleSSOCallbackAction = actionClient
       const cookieCodeVerifier = cookieStore.get(GOOGLE_OAUTH_CODE_VERIFIER_COOKIE_NAME)?.value ?? null;
 
       if (!cookieState || !cookieCodeVerifier) {
-        throw new ActionError(
-          "NOT_AUTHORIZED",
-          t("errorMissingCookies")
-        );
+        throw new ActionError("NOT_AUTHORIZED", { key: "Client.Auth.GoogleCallback.errorMissingCookies" });
       }
 
       if (input.state !== cookieState) {
-        throw new ActionError(
-          "NOT_AUTHORIZED",
-          t("errorInvalidState")
-        );
+        throw new ActionError("NOT_AUTHORIZED", { key: "Client.Auth.GoogleCallback.errorInvalidState" });
       }
 
       let tokens;
@@ -76,10 +64,7 @@ export const googleSSOCallbackAction = actionClient
         tokens = await google.validateAuthorizationCode(input.code, cookieCodeVerifier);
       } catch (error) {
         console.error("Google OAuth callback: Error validating authorization code", error);
-        throw new ActionError(
-          "NOT_AUTHORIZED",
-          t("errorInvalidCode")
-        );
+        throw new ActionError("NOT_AUTHORIZED", { key: "Client.Auth.GoogleCallback.errorInvalidCode" });
       }
 
       const claims = decodeIdToken(tokens.idToken()) as GoogleSSOResponse;
@@ -155,10 +140,7 @@ export const googleSSOCallbackAction = actionClient
           throw error;
         }
 
-        throw new ActionError(
-          "INTERNAL_SERVER_ERROR",
-          tErrors("unexpected")
-        );
+        throw new ActionError("INTERNAL_SERVER_ERROR", { key: "Client.Errors.unexpected" });
       }
     }, RATE_LIMITS.GOOGLE_SSO_CALLBACK);
   });

--- a/src/app/[locale]/(auth)/sso/google/callback/google-callback.client.tsx
+++ b/src/app/[locale]/(auth)/sso/google/callback/google-callback.client.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useEffect, useRef } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useSearchParams } from "next/navigation";
+import { useRouter } from "@/i18n/navigation";
 import { toast } from "sonner";
 import { useAction } from "next-safe-action/hooks";
 import { googleSSOCallbackAction } from "./google-callback.action";

--- a/src/app/[locale]/(auth)/sso/google/route.ts
+++ b/src/app/[locale]/(auth)/sso/google/route.ts
@@ -1,6 +1,7 @@
 import { getSessionFromCookie } from "@/utils/auth";
 import { withRateLimit, RATE_LIMITS } from "@/utils/with-rate-limit";
-import { redirect } from "next/navigation";
+import { redirect as nextRedirect } from "next/navigation";
+import { redirect } from "@/i18n/navigation";
 import { generateState, generateCodeVerifier } from "arctic";
 import { getGoogleSSOClient } from "@/lib/sso/google-sso";
 import { cookies } from "next/headers";
@@ -13,6 +14,8 @@ import ms from "ms";
 import type { ResponseCookie } from "next/dist/compiled/@edge-runtime/cookies";
 import { isGoogleSSOEnabled } from "@/flags";
 import { REDIRECT_AFTER_SIGN_IN } from "@/constants";
+import { getLocale } from "next-intl/server";
+
 const cookieOptions: Partial<ResponseCookie> = {
   path: "/",
   httpOnly: true,
@@ -23,15 +26,18 @@ const cookieOptions: Partial<ResponseCookie> = {
 
 export async function GET() {
   return withRateLimit(async () => {
+    const locale = await getLocale();
+
     if (!(await isGoogleSSOEnabled())) {
       console.error("Google client ID or secret is not set")
-      return redirect('/')
+      return redirect({ href: "/", locale })
     }
 
     const session = await getSessionFromCookie()
 
     if (session) {
-      return redirect(REDIRECT_AFTER_SIGN_IN)
+      // Dashboard lives outside `[locale]`; keep next/navigation redirect.
+      return nextRedirect(REDIRECT_AFTER_SIGN_IN)
     }
 
     let ssoRedirectUrl: null | URL = null
@@ -49,7 +55,7 @@ export async function GET() {
       cookieStore.set(GOOGLE_OAUTH_CODE_VERIFIER_COOKIE_NAME, codeVerifier, cookieOptions)
     } catch (error) {
       console.error('Error generating Google OAuth state and code verifier', error)
-      return redirect('/')
+      return redirect({ href: "/", locale })
     }
 
     return new Response(null, {

--- a/src/app/[locale]/(auth)/team-invite/page.tsx
+++ b/src/app/[locale]/(auth)/team-invite/page.tsx
@@ -1,6 +1,6 @@
 import { Metadata } from "next";
 import { getSessionFromCookie } from "@/utils/auth";
-import { redirect } from "next/navigation";
+import { redirect } from "@/i18n/navigation";
 import { getTranslations } from "next-intl/server";
 import TeamInviteClientComponent from "./team-invite.client";
 import { LOCALES, type Locale } from "@/i18n/config";
@@ -22,22 +22,28 @@ export async function generateMetadata({
 }
 
 export default async function TeamInvitePage({
+  params,
   searchParams,
 }: {
+  params: Promise<{ locale: Locale }>;
   searchParams: Promise<{ token?: string }>;
 }) {
+  const { locale } = await params;
   const session = await getSessionFromCookie();
   const token = (await searchParams)?.token;
 
   // If no token is provided, redirect to sign in
   if (!token) {
-    return redirect('/sign-in');
+    return redirect({ href: "/sign-in", locale });
   }
 
   // If user is not logged in, redirect to sign in with return URL
   if (!session) {
     const returnUrl = `/team-invite?token=${token}`;
-    return redirect(`/sign-in?redirect=${encodeURIComponent(returnUrl)}`);
+    return redirect({
+      href: `/sign-in?redirect=${encodeURIComponent(returnUrl)}`,
+      locale,
+    });
   }
 
   return <TeamInviteClientComponent />;

--- a/src/app/[locale]/(auth)/team-invite/team-invite.action.ts
+++ b/src/app/[locale]/(auth)/team-invite/team-invite.action.ts
@@ -1,7 +1,6 @@
 "use server";
 
 import "server-only";
-import { getTranslations } from "next-intl/server";
 import { teamInviteSchema } from "@/schemas/team-invite.schema";
 import { ActionError } from "@/lib/action-error";
 import { actionClient } from "@/lib/safe-action";
@@ -14,14 +13,12 @@ export const acceptTeamInviteAction = actionClient
   .action(async ({ parsedInput: input }) => {
     return withRateLimit(
       async () => {
-        const t = await getTranslations("Client.Auth.TeamInvite");
         const session = await getSessionFromCookie();
 
         if (!session) {
-          throw new ActionError(
-            "NOT_AUTHORIZED",
-            t("errorMustBeLoggedIn")
-          );
+          throw new ActionError("NOT_AUTHORIZED", {
+            key: "Client.Auth.TeamInvite.errorMustBeLoggedIn",
+          });
         }
 
         try {
@@ -34,10 +31,9 @@ export const acceptTeamInviteAction = actionClient
             throw error;
           }
 
-          throw new ActionError(
-            "INTERNAL_SERVER_ERROR",
-            t("errorUnexpected")
-          );
+          throw new ActionError("INTERNAL_SERVER_ERROR", {
+            key: "Client.Auth.TeamInvite.errorUnexpected",
+          });
         }
       },
       RATE_LIMITS.EMAIL

--- a/src/app/[locale]/(auth)/team-invite/team-invite.client.tsx
+++ b/src/app/[locale]/(auth)/team-invite/team-invite.client.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
+import { useRouter as useLocaleRouter } from "@/i18n/navigation";
 import { toast } from "sonner";
 import { useAction } from "next-safe-action/hooks";
 import { acceptTeamInviteAction } from "./team-invite.action";
@@ -13,6 +14,7 @@ import { useTranslations } from "next-intl";
 
 export default function TeamInviteClientComponent() {
   const router = useRouter();
+  const localeRouter = useLocaleRouter();
   const searchParams = useSearchParams();
   const token = searchParams.get("token");
   const hasCalledAcceptInvite = useRef(false);
@@ -53,7 +55,7 @@ export default function TeamInviteClientComponent() {
         handleAcceptInvite(result.output);
       } else {
         toast.error(t("toastInvalidToken"));
-        router.push("/sign-in");
+        localeRouter.push("/sign-in");
       }
     }
   }, [token]);
@@ -81,7 +83,7 @@ export default function TeamInviteClientComponent() {
         <p className="text-sm text-muted-foreground">
           {error?.code === "CONFLICT"
             ? t("errorAlreadyMember")
-            : error?.code === "FORBIDDEN" && error?.message.includes("limit")
+            : error?.reason === "Client.Dashboard.Teams.errorJoinLimit"
             ? t("errorTeamLimitReached")
             : t("errorExpiredOrRevoked")}
         </p>

--- a/src/app/[locale]/(auth)/verify-email/page.tsx
+++ b/src/app/[locale]/(auth)/verify-email/page.tsx
@@ -1,5 +1,5 @@
 import { Metadata } from "next";
-import { redirect } from "next/navigation";
+import { redirect } from "@/i18n/navigation";
 import { getTranslations } from "next-intl/server";
 import VerifyEmailClientComponent from "./verify-email.client";
 import { REDIRECT_AFTER_SIGN_IN } from "@/constants";
@@ -23,10 +23,13 @@ export async function generateMetadata({
 }
 
 export default async function VerifyEmailPage({
+  params,
   searchParams,
 }: {
+  params: Promise<{ locale: Locale }>;
   searchParams: Promise<{ token?: string }>;
 }) {
+  const { locale } = await params;
   const token = (await searchParams).token;
 
   await redirectAuthenticatedUser({
@@ -35,7 +38,7 @@ export default async function VerifyEmailPage({
   });
 
   if (!token) {
-    return redirect('/sign-in');
+    return redirect({ href: "/sign-in", locale });
   }
 
   return <VerifyEmailClientComponent />;

--- a/src/app/[locale]/(auth)/verify-email/verify-email.action.ts
+++ b/src/app/[locale]/(auth)/verify-email/verify-email.action.ts
@@ -1,7 +1,6 @@
 "use server";
 
 import "server-only";
-import { getTranslations } from "next-intl/server";
 import { getVerificationTokenKey } from "@/utils/auth-utils";
 import { getDB } from "@/db";
 import { userTable } from "@/db/schema";
@@ -18,14 +17,12 @@ export const verifyEmailAction = actionClient
   .action(async ({ parsedInput: input }) => {
     return withRateLimit(
       async () => {
-        const t = await getTranslations("Client.Auth.VerifyEmail");
-        const tErrors = await getTranslations("Client.Errors");
         const verificationToken = await getValidExpiringToken({
           token: input.token,
           key: getVerificationTokenKey,
           notFoundError: {
             code: "NOT_FOUND",
-            message: t("errorTokenNotFound"),
+            message: { key: "Client.Auth.VerifyEmail.errorTokenNotFound" },
           },
         });
 
@@ -37,10 +34,7 @@ export const verifyEmailAction = actionClient
         });
 
         if (!user) {
-          throw new ActionError(
-            "NOT_FOUND",
-            tErrors("userNotFound")
-          );
+          throw new ActionError("NOT_FOUND", { key: "Client.Errors.userNotFound" });
         }
 
         try {
@@ -60,10 +54,7 @@ export const verifyEmailAction = actionClient
         } catch (error) {
           console.error(error);
 
-          throw new ActionError(
-            "INTERNAL_SERVER_ERROR",
-            tErrors("unexpected")
-          );
+          throw new ActionError("INTERNAL_SERVER_ERROR", { key: "Client.Errors.unexpected" });
         }
       },
       RATE_LIMITS.EMAIL

--- a/src/app/[locale]/(auth)/verify-email/verify-email.client.tsx
+++ b/src/app/[locale]/(auth)/verify-email/verify-email.client.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
+import { useRouter as useLocaleRouter } from "@/i18n/navigation";
 import { toast } from "sonner";
 import { useAction } from "next-safe-action/hooks";
 import { verifyEmailAction } from "./verify-email.action";
@@ -15,6 +16,7 @@ import { useTranslations } from "next-intl";
 
 export default function VerifyEmailClientComponent() {
   const router = useRouter();
+  const localeRouter = useLocaleRouter();
   const searchParams = useSearchParams();
   const token = searchParams.get("token");
   const hasCalledVerification = useRef(false);
@@ -48,7 +50,7 @@ export default function VerifyEmailClientComponent() {
         handleVerification(result.output);
       } else {
         toast.error(t("toastInvalidToken"));
-        router.push("/sign-in");
+        localeRouter.push("/sign-in");
       }
     }
   }, [token]);
@@ -70,7 +72,7 @@ export default function VerifyEmailClientComponent() {
         title={t("failedTitle")}
         description={error?.message || t("failedDescription")}
         actionLabel={tCommon("backToSignIn")}
-        onAction={() => router.push("/sign-in")}
+        onAction={() => localeRouter.push("/sign-in")}
       />
     );
   }
@@ -81,7 +83,7 @@ export default function VerifyEmailClientComponent() {
         title={t("invalidLinkTitle")}
         description={t("invalidLinkDescription")}
         actionLabel={tCommon("backToSignIn")}
-        onAction={() => router.push("/sign-in")}
+        onAction={() => localeRouter.push("/sign-in")}
       />
     );
   }

--- a/src/app/[locale]/(legal)/privacy/page.tsx
+++ b/src/app/[locale]/(legal)/privacy/page.tsx
@@ -23,7 +23,12 @@ export async function generateMetadata({
 
 const lastUpdated = new Date('2025-01-15T20:10:16.287Z')
 
-export default async function PrivacyPage() {
+export default async function PrivacyPage({
+  params,
+}: {
+  params: Promise<{ locale: Locale }>;
+}) {
+  const { locale } = await params;
   const { env } = await getCloudflareContext();
   const t = await getTranslations("Legal.Privacy");
 
@@ -33,7 +38,7 @@ export default async function PrivacyPage() {
     <>
       <h1 className="text-4xl font-bold text-foreground mb-8">{t("title")}</h1>
 
-      <p className="text-muted-foreground mb-6">{t("lastUpdated", { date: lastUpdated.toLocaleDateString() })}</p>
+      <p className="text-muted-foreground mb-6">{t("lastUpdated", { date: lastUpdated.toLocaleDateString(locale) })}</p>
 
       <section className="mb-8">
         <h2 className="text-2xl font-semibold text-foreground mb-4">{t("informationWeCollect.heading")}</h2>

--- a/src/app/[locale]/(legal)/terms/page.tsx
+++ b/src/app/[locale]/(legal)/terms/page.tsx
@@ -1,7 +1,6 @@
 import { Metadata } from "next";
 import { buttonVariants } from "@/components/ui/button";
 import { Link } from "@/i18n/navigation";
-import { useTranslations } from "next-intl";
 import { getTranslations } from "next-intl/server";
 import { LOCALES, type Locale } from "@/i18n/config";
 import { buildAlternates } from "@/utils/i18n-metadata";
@@ -23,14 +22,19 @@ export async function generateMetadata({
 
 const lastUpdated = new Date('2025-01-15T20:10:16.287Z')
 
-export default function TermsPage() {
-  const t = useTranslations("Legal.Terms");
+export default async function TermsPage({
+  params,
+}: {
+  params: Promise<{ locale: Locale }>;
+}) {
+  const { locale } = await params;
+  const t = await getTranslations("Legal.Terms");
 
   return (
     <>
       <h1 className="text-4xl font-bold text-foreground mb-8">{t("title")}</h1>
 
-      <p className="text-muted-foreground mb-6">{t("lastUpdated", { date: lastUpdated.toLocaleDateString() })}</p>
+      <p className="text-muted-foreground mb-6">{t("lastUpdated", { date: lastUpdated.toLocaleDateString(locale) })}</p>
 
       <section className="mb-8">
         <h2 className="text-2xl font-semibold text-foreground mb-4">{t("acceptanceOfTerms.heading")}</h2>

--- a/src/app/[locale]/(marketing)/blog/[slug]/page.tsx
+++ b/src/app/[locale]/(marketing)/blog/[slug]/page.tsx
@@ -14,8 +14,9 @@ import { generateMetaDescription } from "@/lib/cms/extract-text-from-content"
 import type { JSONContent } from "@tiptap/core"
 import Image from "next/image"
 import { SITE_NAME, SITE_URL } from "@/constants"
-import { DEFAULT_LOCALE, isLocale, type Locale } from "@/i18n/config"
+import { DEFAULT_LOCALE, getOpenGraphLocales, isLocale, type Locale } from "@/i18n/config"
 import { buildAlternates, noindexNonDefaultLocale } from "@/utils/i18n-metadata"
+import { absoluteLocalizedUrl } from "@/utils/i18n-urls"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { getInitials } from "@/utils/name-initials"
 import { BlogBackLink } from "@/components/blog-back-link"
@@ -26,7 +27,7 @@ import type { BlogPosting, BreadcrumbList, WithContext } from "schema-dts"
 import { BlogListPage, getBlogListPageMetadata } from "../_components/blog-list-page"
 import { getBlogPagePath } from "@/lib/blog-routing"
 import { getValidPageNumber } from "@/utils/get-valid-page-number"
-import { getAuthorRouteParam } from "@/utils/blog-author-url"
+import { getAuthorDisplayName, getAuthorRouteParam } from "@/utils/blog-author-url"
 import { getCmsEntryDates } from "@/utils/cms-entry-dates"
 import { buildTableOfContentsTree } from "@/lib/cms/table-of-contents-tree"
 import { extractTableOfContents } from "@/lib/cms/extract-table-of-contents"
@@ -141,11 +142,9 @@ export async function generateMetadata({
   const validLocales = availableLocales.filter(isLocale)
 
   // A fallback render serves default-locale content under a non-default-locale
-  // prefix (noindexed, mixed-language), so it canonicalizes to the real
+  // prefix (noindexed, mixed-language), so canonical/OG URLs point at the real
   // default-locale URL; hreflang still lists only genuine translations.
-  const alternates = isFallback
-    ? buildAlternates({ pathname: `/blog/${slug}`, locale: DEFAULT_LOCALE, availableLocales: validLocales })
-    : buildAlternates({ pathname: `/blog/${slug}`, locale, availableLocales: validLocales })
+  const alternates = buildAlternates({ pathname: `/blog/${slug}`, locale: displayLocale, availableLocales: validLocales })
 
   return {
     title: entry.title,
@@ -153,10 +152,11 @@ export async function generateMetadata({
     ...(isFallback ? noindexNonDefaultLocale(locale) : {}),
     alternates,
     openGraph: {
+      ...getOpenGraphLocales(displayLocale),
       title: entry.title,
       description: description || entry.title,
       type: 'article',
-      url: `/blog/${slug}`,
+      url: absoluteLocalizedUrl({ pathname: `/blog/${slug}`, locale: displayLocale }),
       publishedTime: publishedDate.toISOString(),
       modifiedTime: modifiedDate.toISOString(),
       ...(authorName && { authors: [authorName] }),
@@ -206,7 +206,7 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
     }
 
     if (!(await hasPublishedBlogPosts())) {
-      redirect("/")
+      redirectLocalized({ href: "/", locale })
     }
 
     notFound()
@@ -226,7 +226,7 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
 
   if (!resolved) {
     if (!(await hasPublishedBlogPosts())) {
-      redirect("/")
+      redirectLocalized({ href: "/", locale })
     }
 
     notFound()
@@ -235,9 +235,10 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
   const { entry, isFallback } = resolved
 
   const author = entry.createdByUser
+  const tAuthor = await getTranslations("Blog.AuthorDetail")
   const authorName = author
-    ? [author.firstName, author.lastName].filter(Boolean).join(' ') || author.email || 'Unknown Author'
-    : 'Unknown Author'
+    ? getAuthorDisplayName(author, tAuthor("unknownAuthor"))
+    : tAuthor("unknownAuthor")
 
   // A fallback render serves default-locale content, so localize tags to the
   // body's real language, not the URL's.
@@ -259,9 +260,9 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
     headline: entry.title,
     // A fallback render serves the default-locale body under a
     // non-default prefix, so advertise the body's real language, not the URL's.
-    inLanguage: isFallback ? DEFAULT_LOCALE : locale,
+    inLanguage: displayLocale,
     description: entry.seoDescription || generateMetaDescription(entry.content as JSONContent),
-    url: `${SITE_URL}/blog/${entry.slug}`,
+    url: absoluteLocalizedUrl({ pathname: `/blog/${entry.slug}`, locale: displayLocale }),
     datePublished: publishedDate.toISOString(),
     dateModified: modifiedDate.toISOString(),
     ...(entry.featuredImageUrl && {
@@ -271,7 +272,7 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
       author: {
         "@type": "Person",
         name: authorName,
-        url: `${SITE_URL}/blog/authors/${getAuthorRouteParam(author)}`,
+        url: absoluteLocalizedUrl({ pathname: `/blog/authors/${getAuthorRouteParam(author)}`, locale: displayLocale }),
         ...(author.avatar && {
           image: `${SITE_URL}${author.avatar}`,
         }),
@@ -282,7 +283,7 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
     }),
     mainEntityOfPage: {
       "@type": "WebPage",
-      "@id": `${SITE_URL}/blog/${entry.slug}`,
+      "@id": absoluteLocalizedUrl({ pathname: `/blog/${entry.slug}`, locale: displayLocale }),
     },
     publisher: {
       "@type": "Organization",
@@ -303,19 +304,19 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
         "@type": "ListItem",
         position: 1,
         name: tCrumb("home"),
-        item: SITE_URL,
+        item: absoluteLocalizedUrl({ pathname: "/", locale: displayLocale }),
       },
       {
         "@type": "ListItem",
         position: 2,
         name: tCrumb("blog"),
-        item: `${SITE_URL}/blog`,
+        item: absoluteLocalizedUrl({ pathname: "/blog", locale: displayLocale }),
       },
       {
         "@type": "ListItem",
         position: 3,
         name: entry.title,
-        item: `${SITE_URL}/blog/${entry.slug}`,
+        item: absoluteLocalizedUrl({ pathname: `/blog/${entry.slug}`, locale: displayLocale }),
       },
     ],
   }
@@ -367,10 +368,10 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
                     )}
                   >
                     <time dateTime={publishedDate.toISOString()}>
-                      {formatDate(publishedDate)}
+                      {formatDate(publishedDate, displayLocale)}
                     </time>
                     {modifiedDate.getTime() !== publishedDate.getTime() && (
-                      <span>{t("updated", { date: formatDate(modifiedDate) })}</span>
+                      <span>{t("updated", { date: formatDate(modifiedDate, displayLocale) })}</span>
                     )}
                   </div>
                 </div>
@@ -415,7 +416,10 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
                 <p className="font-mono text-xs uppercase tracking-[0.2em] text-edge">
                   {t("onThisPage")}
                 </p>
-                <ContentTableOfContentsNav nodes={tableOfContentsTree} />
+                <ContentTableOfContentsNav
+                  nodes={tableOfContentsTree}
+                  ariaLabel={t("onThisPage")}
+                />
               </div>
             </aside>
           )}

--- a/src/app/[locale]/(marketing)/blog/_components/blog-list-page.tsx
+++ b/src/app/[locale]/(marketing)/blog/_components/blog-list-page.tsx
@@ -1,6 +1,6 @@
 import "server-only"
-import { Link } from "@/i18n/navigation"
-import { notFound, redirect } from "next/navigation"
+import { Link, redirect } from "@/i18n/navigation"
+import { notFound } from "next/navigation"
 import type { Metadata } from "next"
 import type { Blog, WithContext } from "schema-dts"
 import { getTranslations } from "next-intl/server"
@@ -13,8 +13,9 @@ import { BLOG_POSTS_PER_PAGE } from "@/constants"
 import { getBlogPagePath } from "@/lib/blog-routing"
 import { hasPublishedBlogPosts } from "@/lib/blog-visibility"
 import { getCmsEntryDates } from "@/utils/cms-entry-dates"
-import { LOCALES, type Locale } from "@/i18n/config"
+import { getOpenGraphLocales, LOCALES, type Locale } from "@/i18n/config"
 import { buildAlternates } from "@/utils/i18n-metadata"
+import { absoluteLocalizedUrl } from "@/utils/i18n-urls"
 
 interface BlogListPageProps {
   page: number;
@@ -35,10 +36,11 @@ export async function getBlogListPageMetadata({ page, locale }: { page: number; 
     // locale-filtered posts), so every locale gets an hreflang entry.
     alternates: buildAlternates({ pathname: pagePath, locale, availableLocales: LOCALES }),
     openGraph: {
+      ...getOpenGraphLocales(locale),
       title,
       description,
       type: "website",
-      url: pagePath,
+      url: absoluteLocalizedUrl({ pathname: pagePath, locale }),
     },
     twitter: {
       card: "summary",
@@ -72,7 +74,7 @@ export async function BlogListPage({ page, locale }: BlogListPageProps) {
   // Only bounce home when the blog has no published posts at all; a locale with
   // no translated posts still renders its localized empty state below.
   if (totalCount === 0 && page === 1 && !(await hasPublishedBlogPosts())) {
-    redirect("/")
+    redirect({ href: "/", locale })
   }
 
   if (page < 1 || (page > 1 && (totalCount === 0 || page > totalPages))) {

--- a/src/app/[locale]/(marketing)/blog/authors/[authorId]/page.tsx
+++ b/src/app/[locale]/(marketing)/blog/authors/[authorId]/page.tsx
@@ -1,6 +1,7 @@
 import "server-only"
 import { cache } from "react"
-import { notFound, redirect } from "next/navigation"
+import { notFound } from "next/navigation"
+import { redirect } from "@/i18n/navigation"
 import type { Metadata } from "next"
 import { getTranslations } from "next-intl/server"
 import { getCmsCollection } from "@/lib/cms/entry"
@@ -16,8 +17,9 @@ import {
   parseAuthorIdFromRouteParam,
 } from "@/utils/blog-author-url"
 import type { Person, WithContext } from "schema-dts"
-import { LOCALES, type Locale } from "@/i18n/config"
+import { getOpenGraphLocales, LOCALES, type Locale } from "@/i18n/config"
 import { buildAlternates } from "@/utils/i18n-metadata"
+import { absoluteLocalizedUrl } from "@/utils/i18n-urls"
 
 type AuthorPageProps = {
   params: Promise<{
@@ -39,6 +41,7 @@ export async function generateMetadata({
 }: AuthorPageProps): Promise<Metadata> {
   const { locale, authorId: authorRouteParam } = await params
   const t = await getTranslations({ locale, namespace: "Blog.AuthorDetail.meta" })
+  const tDetail = await getTranslations({ locale, namespace: "Blog.AuthorDetail" })
   const parsedAuthorId = parseAuthorIdFromRouteParam(authorRouteParam)
 
   if (!parsedAuthorId) {
@@ -60,7 +63,7 @@ export async function generateMetadata({
   }
 
   const author = authorEntries[0].createdByUser!
-  const authorName = getAuthorDisplayName(author)
+  const authorName = getAuthorDisplayName(author, tDetail("unknownAuthor"))
   const canonicalAuthorParam = getAuthorRouteParam(author)
 
   const avatarUrl = author.avatar ? `${SITE_URL}${author.avatar}` : undefined
@@ -79,10 +82,11 @@ export async function generateMetadata({
       availableLocales: LOCALES,
     }),
     openGraph: {
+      ...getOpenGraphLocales(locale),
       title,
       description,
       type: "profile",
-      url: `/blog/authors/${canonicalAuthorParam}`,
+      url: absoluteLocalizedUrl({ pathname: `/blog/authors/${canonicalAuthorParam}`, locale }),
       ...(avatarUrl && {
         images: [avatarUrl],
       }),
@@ -112,7 +116,7 @@ export default async function AuthorPage({ params }: AuthorPageProps) {
   // Empty only in this locale falls through to the per-author notFound below;
   // redirect home only when the blog has no published posts at all.
   if (blogEntries.length === 0 && !(await hasPublishedBlogPosts())) {
-    redirect("/")
+    redirect({ href: "/", locale })
   }
 
   const authorEntries = blogEntries.filter(
@@ -124,11 +128,11 @@ export default async function AuthorPage({ params }: AuthorPageProps) {
   }
 
   const author = authorEntries[0].createdByUser!
-  const authorName = getAuthorDisplayName(author)
+  const authorName = getAuthorDisplayName(author, t("unknownAuthor"))
   const canonicalAuthorParam = getAuthorRouteParam(author)
 
   if (authorRouteParam !== canonicalAuthorParam) {
-    redirect(`/blog/authors/${canonicalAuthorParam}`)
+    redirect({ href: `/blog/authors/${canonicalAuthorParam}`, locale })
   }
 
   // JSON-LD structured data for Person
@@ -136,7 +140,7 @@ export default async function AuthorPage({ params }: AuthorPageProps) {
     "@context": "https://schema.org",
     "@type": "Person",
     name: authorName,
-    url: `${SITE_URL}/blog/authors/${canonicalAuthorParam}`,
+    url: absoluteLocalizedUrl({ pathname: `/blog/authors/${canonicalAuthorParam}`, locale }),
     ...(author.avatar && {
       image: `${SITE_URL}${author.avatar}`,
     }),

--- a/src/app/[locale]/(marketing)/blog/authors/page.tsx
+++ b/src/app/[locale]/(marketing)/blog/authors/page.tsx
@@ -1,6 +1,5 @@
 import "server-only"
-import { Link } from "@/i18n/navigation"
-import { redirect } from "next/navigation"
+import { Link, redirect } from "@/i18n/navigation"
 import type { Metadata } from "next"
 import { getTranslations } from "next-intl/server"
 import { getCmsCollection } from "@/lib/cms/entry"
@@ -12,8 +11,9 @@ import { BlogBackLink } from "@/components/blog-back-link"
 import { BlogEmptyState } from "@/components/blog-empty-state"
 import { HairlineGrid } from "@/components/hairline-grid"
 import type { CollectionPage, WithContext } from "schema-dts"
-import { LOCALES, type Locale } from "@/i18n/config"
+import { getOpenGraphLocales, LOCALES, type Locale } from "@/i18n/config"
 import { buildAlternates } from "@/utils/i18n-metadata"
+import { absoluteLocalizedUrl } from "@/utils/i18n-urls"
 
 export async function generateMetadata({
   params,
@@ -32,10 +32,11 @@ export async function generateMetadata({
     // hreflang entry.
     alternates: buildAlternates({ pathname: "/blog/authors", locale, availableLocales: LOCALES }),
     openGraph: {
+      ...getOpenGraphLocales(locale),
       title,
       description,
       type: "website",
-      url: "/blog/authors",
+      url: absoluteLocalizedUrl({ pathname: "/blog/authors", locale }),
     },
     twitter: {
       card: "summary",
@@ -51,6 +52,8 @@ export default async function BlogAuthorsPage({
   params: Promise<{ locale: Locale }>;
 }) {
   const t = await getTranslations("Blog.Authors")
+  const tAuthor = await getTranslations("Blog.AuthorDetail")
+  const unknownAuthor = tAuthor("unknownAuthor")
   const { locale } = await params
 
   const blogEntries = await getCmsCollection({
@@ -62,7 +65,7 @@ export default async function BlogAuthorsPage({
   // Empty only in this locale still renders the localized empty state; redirect
   // home only when the blog has no published posts at all.
   if (blogEntries.length === 0 && !(await hasPublishedBlogPosts())) {
-    redirect("/")
+    redirect({ href: "/", locale })
   }
 
   // Group entries by author
@@ -112,7 +115,7 @@ export default async function BlogAuthorsPage({
           position: index + 1,
           item: {
             "@type": "Person",
-            name: getAuthorDisplayName(author),
+            name: getAuthorDisplayName(author, unknownAuthor),
             ...(author.email && {
               email: author.email,
             }),
@@ -155,14 +158,14 @@ export default async function BlogAuthorsPage({
                 />
                 <div className="flex items-center gap-4">
                   <Avatar className="h-12 w-12 ring-1 ring-border">
-                    {author.avatar && <AvatarImage src={author.avatar} alt={getAuthorDisplayName(author)} />}
+                    {author.avatar && <AvatarImage src={author.avatar} alt={getAuthorDisplayName(author, unknownAuthor)} />}
                     <AvatarFallback>
-                      {getInitials(getAuthorDisplayName(author))}
+                      {getInitials(getAuthorDisplayName(author, unknownAuthor))}
                     </AvatarFallback>
                   </Avatar>
                   <div className="min-w-0">
                     <h2 className="truncate font-display text-lg font-semibold text-foreground transition-colors group-hover:text-edge">
-                      {getAuthorDisplayName(author)}
+                      {getAuthorDisplayName(author, unknownAuthor)}
                     </h2>
                     <p className="mt-0.5 font-mono text-xs text-muted-foreground">
                       {t("postCount", { count: author.postCount })}

--- a/src/app/[locale]/(marketing)/blog/tags/[slug]/page.tsx
+++ b/src/app/[locale]/(marketing)/blog/tags/[slug]/page.tsx
@@ -1,5 +1,6 @@
 import "server-only"
-import { notFound, redirect } from "next/navigation"
+import { notFound } from "next/navigation"
+import { redirect } from "@/i18n/navigation"
 import type { Metadata } from "next"
 import { getTranslations } from "next-intl/server"
 import { getCmsCollection } from "@/lib/cms/entry"
@@ -10,8 +11,9 @@ import { BlogBackLink } from "@/components/blog-back-link"
 import { BlogEmptyState } from "@/components/blog-empty-state"
 import type { CollectionPage, WithContext } from "schema-dts"
 import { getCmsEntryDates } from "@/utils/cms-entry-dates"
-import { LOCALES, type Locale } from "@/i18n/config"
+import { getOpenGraphLocales, LOCALES, type Locale } from "@/i18n/config"
 import { buildAlternates } from "@/utils/i18n-metadata"
+import { absoluteLocalizedUrl } from "@/utils/i18n-urls"
 
 type TagPageProps = {
   params: Promise<{
@@ -44,10 +46,11 @@ export async function generateMetadata({
     // hreflang entry.
     alternates: buildAlternates({ pathname: `/blog/tags/${slug}`, locale, availableLocales: LOCALES }),
     openGraph: {
+      ...getOpenGraphLocales(locale),
       title,
       description,
       type: "website",
-      url: `/blog/tags/${slug}`,
+      url: absoluteLocalizedUrl({ pathname: `/blog/tags/${slug}`, locale }),
     },
     twitter: {
       card: "summary",
@@ -77,7 +80,7 @@ export default async function TagPage({ params }: TagPageProps) {
   // Empty only in this locale still renders the localized empty state below;
   // redirect home only when the blog has no published posts at all.
   if (allBlogEntries.length === 0 && !(await hasPublishedBlogPosts())) {
-    redirect("/")
+    redirect({ href: "/", locale })
   }
 
   const blogEntries = allBlogEntries.filter(entry =>

--- a/src/app/[locale]/(marketing)/blog/tags/page.tsx
+++ b/src/app/[locale]/(marketing)/blog/tags/page.tsx
@@ -1,6 +1,5 @@
 import "server-only"
-import { Link } from "@/i18n/navigation"
-import { redirect } from "next/navigation"
+import { Link, redirect } from "@/i18n/navigation"
 import type { Metadata } from "next"
 import { getTranslations } from "next-intl/server"
 import { getCmsTags } from "@/lib/cms/tags"
@@ -8,8 +7,9 @@ import { BlogBackLink } from "@/components/blog-back-link"
 import { BlogEmptyState } from "@/components/blog-empty-state"
 import { HairlineGrid } from "@/components/hairline-grid"
 import type { CollectionPage, WithContext } from "schema-dts"
-import { LOCALES, type Locale } from "@/i18n/config"
+import { getOpenGraphLocales, LOCALES, type Locale } from "@/i18n/config"
 import { buildAlternates } from "@/utils/i18n-metadata"
+import { absoluteLocalizedUrl } from "@/utils/i18n-urls"
 
 export async function generateMetadata({
   params,
@@ -28,10 +28,11 @@ export async function generateMetadata({
     // hreflang entry.
     alternates: buildAlternates({ pathname: "/blog/tags", locale, availableLocales: LOCALES }),
     openGraph: {
+      ...getOpenGraphLocales(locale),
       title,
       description,
       type: "website",
-      url: "/blog/tags",
+      url: absoluteLocalizedUrl({ pathname: "/blog/tags", locale }),
     },
     twitter: {
       card: "summary",
@@ -53,10 +54,10 @@ export default async function BlogTagsPage({
   // Only show tags that have entries, most-published topics first
   const tagsWithEntries = tags
     .filter(tag => tag.entryCount > 0)
-    .sort((a, b) => b.entryCount - a.entryCount || a.name.localeCompare(b.name))
+    .sort((a, b) => b.entryCount - a.entryCount || a.name.localeCompare(b.name, locale))
 
   if (tagsWithEntries.length === 0) {
-    redirect("/")
+    redirect({ href: "/", locale })
   }
 
   // JSON-LD structured data for CollectionPage

--- a/src/app/[locale]/(marketing)/docs/[[...slug]]/page.tsx
+++ b/src/app/[locale]/(marketing)/docs/[[...slug]]/page.tsx
@@ -30,9 +30,10 @@ import { getCmsNavigationConfig } from "@/lib/cms/cms-navigation-config";
 import { resolveDocsPage } from "@/lib/cms/resolve-docs-page";
 import { cn } from "@/lib/utils";
 import { CMS_NAVIGATION_NODE_TYPES, getNavigationNodeDisplayTitle } from "@/types/cms-navigation";
-import { DEFAULT_LOCALE, LOCALES, type Locale } from "@/i18n/config";
+import { DEFAULT_LOCALE, getOpenGraphLocales, isLocale, LOCALES, type Locale } from "@/i18n/config";
 import { Link, permanentRedirect, redirect } from "@/i18n/navigation";
 import { buildAlternates, noindexNonDefaultLocale } from "@/utils/i18n-metadata";
+import { absoluteLocalizedUrl } from "@/utils/i18n-urls";
 
 interface DocsPageProps {
   params: Promise<{
@@ -125,9 +126,10 @@ export async function generateMetadata({
       keywords: childTitles,
       alternates: buildAlternates({ pathname: canonicalPath, locale, availableLocales: LOCALES }),
       openGraph: {
+        ...getOpenGraphLocales(locale),
         title: groupTitle,
         description,
-        url: canonicalPath,
+        url: absoluteLocalizedUrl({ pathname: canonicalPath, locale }),
         type: "website",
       },
       twitter: {
@@ -160,10 +162,11 @@ export async function generateMetadata({
   // A fallback render serves default-locale content under a non-default-locale
   // prefix (noindexed, mixed-language), so it canonicalizes to the real
   // default-locale URL; hreflang still lists only genuine translations.
+  const urlLocale = isFallback ? DEFAULT_LOCALE : locale;
   const alternates = buildAlternates({
     pathname: canonicalPath,
-    locale: isFallback ? DEFAULT_LOCALE : locale,
-    availableLocales: availableLocales as Locale[],
+    locale: urlLocale,
+    availableLocales: availableLocales.filter(isLocale),
   });
 
   return {
@@ -172,9 +175,10 @@ export async function generateMetadata({
     ...(isFallback ? noindexNonDefaultLocale(locale) : {}),
     alternates,
     openGraph: {
+      ...getOpenGraphLocales(urlLocale),
       title: entry.title,
       description,
-      url: canonicalPath,
+      url: absoluteLocalizedUrl({ pathname: canonicalPath, locale: urlLocale }),
       type: "article",
       ...(featuredImageUrl
         ? {
@@ -229,6 +233,7 @@ export default async function DocsPage({ params }: DocsPageProps) {
   }
 
   const { node, navigationTree } = result;
+  const urlLocale = result.type === "page" && result.isFallback ? DEFAULT_LOCALE : locale;
   const nodeTitle = getNavigationNodeDisplayTitle(node);
   const breadcrumbs = getCmsNavigationAncestors({
     nodeId: node.id,
@@ -242,25 +247,31 @@ export default async function DocsPage({ params }: DocsPageProps) {
         "@type": "ListItem",
         position: 1,
         name: tCrumb("home"),
-        item: SITE_URL,
+        item: absoluteLocalizedUrl({ pathname: "/", locale: urlLocale }),
       },
       {
         "@type": "ListItem",
         position: 2,
         name: t("docs"),
-        item: `${SITE_URL}${docsBasePath}`,
+        item: absoluteLocalizedUrl({ pathname: docsBasePath, locale: urlLocale }),
       },
       ...breadcrumbs.map((crumb, index) => ({
         "@type": "ListItem",
         position: index + 3,
         name: getNavigationNodeDisplayTitle(crumb),
-        item: `${SITE_URL}${crumb.resolvedPath ?? docsBasePath}`,
+        item: absoluteLocalizedUrl({
+          pathname: crumb.resolvedPath ?? docsBasePath,
+          locale: urlLocale,
+        }),
       })),
       {
         "@type": "ListItem",
         position: breadcrumbs.length + 3,
         name: nodeTitle,
-        item: `${SITE_URL}${node.resolvedPath ?? docsBasePath}`,
+        item: absoluteLocalizedUrl({
+          pathname: node.resolvedPath ?? docsBasePath,
+          locale: urlLocale,
+        }),
       },
     ],
   };
@@ -289,12 +300,12 @@ export default async function DocsPage({ params }: DocsPageProps) {
     const groupItemListJsonLd = {
       "@context": "https://schema.org",
       "@type": "ItemList",
-      name: `${nodeTitle} documentation`,
+      name: t("groupListName", { group: nodeTitle }),
       itemListElement: children.map((child, index) => ({
         "@type": "ListItem",
         position: index + 1,
         name: getNavigationNodeDisplayTitle(child),
-        url: `${SITE_URL}${child.resolvedPath}`,
+        url: absoluteLocalizedUrl({ pathname: child.resolvedPath!, locale: urlLocale }),
         description: getNavigationItemDescription(child) ?? undefined,
       })),
     };
@@ -366,7 +377,7 @@ export default async function DocsPage({ params }: DocsPageProps) {
     slug: entry.slug,
     // Use the resolved entry's own locale (not the URL locale) so the TOC matches
     // the rendered body — including untranslated docs that fall back to DEFAULT_LOCALE.
-    locale: entry.locale as Locale,
+    locale: isLocale(entry.locale) ? entry.locale : DEFAULT_LOCALE,
   });
 
   if (!artifacts) {

--- a/src/app/[locale]/(marketing)/docs/_components/docs-navigation-chrome.tsx
+++ b/src/app/[locale]/(marketing)/docs/_components/docs-navigation-chrome.tsx
@@ -1,12 +1,11 @@
 import "server-only";
 
-import { redirect } from "next/navigation";
 import { getLocale, getTranslations } from "next-intl/server";
 
 import { Skeleton } from "@/components/ui/skeleton";
 import { getCmsNavigationTree } from "@/lib/cms/cms-navigation-repository";
 import { DOCS_SLUG } from "@/lib/cms/docs-config";
-import type { Locale } from "@/i18n/config";
+import { redirect } from "@/i18n/navigation";
 
 import { DocsLlmsTxtLink } from "./docs-llms-txt-link";
 import { DocsSearch } from "./docs-search";
@@ -15,7 +14,7 @@ import { MobileDocsNav } from "./mobile-docs-nav";
 
 export async function DocsNavigationChrome() {
   const t = await getTranslations("Client.Docs.Navigation");
-  const locale = (await getLocale()) as Locale;
+  const locale = await getLocale();
   // Locale-scoped tree: PAGE nodes untranslated in the active locale are
   // pruned out by `getCmsNavigationTree` (see cms-navigation-repository.ts),
   // so the sidebar naturally shows only translated entries for that locale.
@@ -25,7 +24,7 @@ export async function DocsNavigationChrome() {
   });
 
   if (sidebarTree.length === 0) {
-    redirect("/");
+    redirect({ href: "/", locale });
   }
 
   return (
@@ -63,13 +62,13 @@ export async function DocsNavigationChrome() {
 export function DocsNavigationChromeFallback() {
   // Kept synchronous (no getTranslations) because this is used directly as a
   // <Suspense fallback> element, which must resolve without awaiting a promise.
+  // Omit the heading text — skeletons only — so we don't flash English copy
+  // on non-default locales.
   return (
     <>
       <aside className="hidden border-r bg-muted/20 py-10 lg:block">
         <div className="sticky top-10 flex max-h-[calc(100vh-5rem)] flex-col">
-          <p className="mb-4 px-6 text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
-            Documentation
-          </p>
+          <Skeleton className="mb-4 ml-6 h-3 w-28" />
           <div className="flex min-h-0 flex-col gap-3 overflow-y-auto">
             <div className="space-y-3 px-3">
               <Skeleton className="h-10 w-full" />
@@ -87,9 +86,7 @@ export function DocsNavigationChromeFallback() {
 
       <div className="border-b px-4 py-4 lg:hidden">
         <div className="space-y-3">
-          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
-            Documentation
-          </p>
+          <Skeleton className="h-3 w-28" />
           <div className="flex items-center gap-3">
             <Skeleton className="h-11 flex-1" />
             <Skeleton className="h-11 w-32" />

--- a/src/app/[locale]/(marketing)/docs/_components/docs-on-this-page-nav.tsx
+++ b/src/app/[locale]/(marketing)/docs/_components/docs-on-this-page-nav.tsx
@@ -1,3 +1,5 @@
+import { getTranslations } from "next-intl/server";
+
 import { ContentTableOfContentsNav } from "@/components/content-table-of-contents-nav";
 import type { TableOfContentsNode } from "@/lib/cms/table-of-contents-tree";
 
@@ -5,6 +7,8 @@ interface DocsOnThisPageNavProps {
   nodes: TableOfContentsNode[];
 }
 
-export function DocsOnThisPageNav({ nodes }: DocsOnThisPageNavProps) {
-  return <ContentTableOfContentsNav nodes={nodes} />;
+export async function DocsOnThisPageNav({ nodes }: DocsOnThisPageNavProps) {
+  const t = await getTranslations("Client.Docs.Page");
+
+  return <ContentTableOfContentsNav nodes={nodes} ariaLabel={t("onThisPage")} />;
 }

--- a/src/app/[locale]/(marketing)/docs/_components/docs-search.tsx
+++ b/src/app/[locale]/(marketing)/docs/_components/docs-search.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import { SearchIcon } from "lucide-react";
-import { useRouter } from "next/navigation";
+import { useRouter } from "@/i18n/navigation";
 import type { Route } from "next";
 import { useLocale, useTranslations } from "next-intl";
 import { useHotkeys } from "react-hotkeys-hook";

--- a/src/app/[locale]/(marketing)/docs/_components/docs-sidebar.tsx
+++ b/src/app/[locale]/(marketing)/docs/_components/docs-sidebar.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import { useEffect, useRef } from "react";
-import { usePathname } from "next/navigation";
 import { FileText, FolderTree } from "lucide-react";
+import { useTranslations } from "next-intl";
 
-import { Link } from "@/i18n/navigation";
+import { Link, usePathname } from "@/i18n/navigation";
 import { cn } from "@/lib/utils";
 import type { CmsNavigationTreeNode } from "@/lib/cms/cms-navigation-repository";
 import { CMS_NAVIGATION_NODE_TYPES, getNavigationNodeDisplayTitle } from "@/types/cms-navigation";
@@ -79,6 +79,7 @@ function DocsSidebarNode({
 export function DocsSidebar({ nodes, className, onNavigate }: DocsSidebarProps) {
   const pathname = usePathname();
   const navRef = useRef<HTMLElement | null>(null);
+  const t = useTranslations("Client.Docs.Navigation");
 
   useEffect(() => {
     const activeItem = navRef.current?.querySelector<HTMLElement>('[data-active="true"]');
@@ -86,7 +87,7 @@ export function DocsSidebar({ nodes, className, onNavigate }: DocsSidebarProps) 
   }, [pathname]);
 
   return (
-    <nav ref={navRef} className={cn("space-y-3 px-3", className)} aria-label="Docs navigation">
+    <nav ref={navRef} className={cn("space-y-3 px-3", className)} aria-label={t("navAriaLabel")}>
       {nodes.map((node) => (
         <DocsSidebarNode
           key={node.id}

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -4,7 +4,8 @@ import { hasLocale } from "next-intl";
 import { setRequestLocale } from "next-intl/server";
 
 import { routing } from "@/i18n/routing";
-import { DEFAULT_LOCALE, LOCALE_OG_MAP } from "@/i18n/config";
+import { DEFAULT_LOCALE } from "@/i18n/config";
+import { buildSiteOpenGraph } from "@/utils/i18n-metadata";
 
 export function generateStaticParams() {
   return routing.locales.map((locale) => ({ locale }));
@@ -19,7 +20,7 @@ export async function generateMetadata({
   const resolved = hasLocale(routing.locales, locale) ? locale : DEFAULT_LOCALE;
 
   return {
-    openGraph: { locale: LOCALE_OG_MAP[resolved] },
+    openGraph: await buildSiteOpenGraph(resolved),
   };
 }
 

--- a/src/app/api/docs/search/route.ts
+++ b/src/app/api/docs/search/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { getTranslations } from "next-intl/server";
 
 import { SITE_URL } from "@/constants";
 import { searchDocs } from "@/lib/cms/cms-search";
@@ -56,9 +57,18 @@ export async function GET(request: Request) {
     );
   } catch (error) {
     if (error instanceof RateLimitError) {
+      // `RateLimitError.message` is log-only English; translate for the caller
+      // using the validated `locale` query param (defaults to DEFAULT_LOCALE).
+      const t = await getTranslations({
+        locale: parseResult.output.locale,
+        namespace: "Client.Errors",
+      });
+
       return NextResponse.json(
         {
-          error: error.message,
+          error: t("rateLimitExceeded", {
+            minutes: Math.ceil(error.retryAfterSeconds / 60),
+          }),
         },
         {
           status: 429,

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,10 +2,12 @@ import type { Metadata } from "next";
 import "./globals.css";
 import "server-only";
 
-import { NextIntlClientProvider } from "next-intl";
+import { hasLocale, NextIntlClientProvider } from "next-intl";
 import { getLocale, getTranslations } from "next-intl/server";
 
 import { getClientMessages } from "@/i18n/client-messages";
+import { DEFAULT_LOCALE } from "@/i18n/config";
+import { routing } from "@/i18n/routing";
 
 import { ThemeProvider } from "@/components/providers";
 import { NavigationTopLoader } from "@/components/navigation-top-loader";
@@ -16,12 +18,15 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { SITE_NAME, SITE_URL } from "@/constants";
 import { getPublicConfig } from "@/flags";
 import { PublicConfigHydrator } from "@/components/public-config-hydrator";
+import { buildSiteOpenGraph } from "@/utils/i18n-metadata";
 
 export async function generateMetadata(): Promise<Metadata> {
   // The site-wide default description lives in the locale catalogs
   // (Client.Landing.meta) so it stays in sync with the localized landing page.
   const t = await getTranslations("Client.Landing.meta");
   const description = t("description");
+  const locale = await getLocale();
+  const resolved = hasLocale(routing.locales, locale) ? locale : DEFAULT_LOCALE;
 
   return {
     title: {
@@ -32,14 +37,7 @@ export async function generateMetadata(): Promise<Metadata> {
     metadataBase: new URL(SITE_URL),
     authors: [{ name: "Lubomir Georgiev" }],
     creator: "Lubomir Georgiev",
-    openGraph: {
-      type: "website",
-      locale: "en_US",
-      url: SITE_URL,
-      title: SITE_NAME,
-      description,
-      siteName: SITE_NAME,
-    },
+    openGraph: await buildSiteOpenGraph(resolved),
     twitter: {
       card: "summary_large_image",
       title: SITE_NAME,

--- a/src/app/sitemap-alternates.test.ts
+++ b/src/app/sitemap-alternates.test.ts
@@ -5,18 +5,6 @@ import { DEFAULT_LOCALE, LOCALES, type Locale } from "@/i18n/config";
 
 vi.mock("server-only", () => ({}));
 
-// `@/i18n/navigation` re-exports next-intl's `createNavigation` helpers, which pull in `next/navigation`
-// client hooks that don't resolve in a plain Node/vitest module graph (no Vinext/Vite shim present).
-// `getPathname` itself is pure path-building logic, so fake it directly against the routing shape instead of exercising next-intl/next's internals here (same resolution quirk documented in `src/utils/i18n-metadata.test.ts`).
-vi.mock("@/i18n/navigation", async () => {
-  const { DEFAULT_LOCALE } = await import("@/i18n/config");
-
-  return {
-    getPathname: ({ href, locale }: { href: string; locale: string }) =>
-      locale === DEFAULT_LOCALE ? href : `/${locale}${href}`,
-  };
-});
-
 const NON_DEFAULT_LOCALE = LOCALES.find((locale) => locale !== DEFAULT_LOCALE) as Locale;
 
 const { localizedSitemapAlternates, entryAlternates } = await import("./sitemap-alternates");
@@ -54,19 +42,19 @@ describe.skipIf(!I18N_ENABLED)("localizedSitemapAlternates", () => {
     }
   });
 
-  test("URLs use locale-specific pathnames from getPathname", () => {
+  test("URLs use locale-prefixed pathnames", () => {
     const languages = localizedSitemapAlternates("/privacy");
 
     expect(languages[DEFAULT_LOCALE]).toBe(`${SITE_URL}/privacy`);
     expect(languages[NON_DEFAULT_LOCALE]).toBe(`${SITE_URL}/${NON_DEFAULT_LOCALE}/privacy`);
   });
 
-  test("root path resolves per-locale using the mocked getPathname output", () => {
+  test("root path resolves per-locale", () => {
     const languages = localizedSitemapAlternates("/");
 
     expect(languages[DEFAULT_LOCALE]).toBe(new URL("/", SITE_URL).toString());
     expect(languages[NON_DEFAULT_LOCALE]).toBe(
-      new URL(`/${NON_DEFAULT_LOCALE}/`, SITE_URL).toString(),
+      new URL(`/${NON_DEFAULT_LOCALE}`, SITE_URL).toString(),
     );
   });
 });

--- a/src/components/aski-chat-sticky-banner.tsx
+++ b/src/components/aski-chat-sticky-banner.tsx
@@ -5,6 +5,7 @@ import { ChevronLeft, X } from "lucide-react";
 import { AskiChatLogo } from "@/components/aski-chat-logo";
 import { cn } from "@/lib/utils";
 import { Button, buttonVariants } from "./ui/button";
+import { useTranslations } from "next-intl";
 
 const STORAGE_KEY = "aski-chat-banner-collapsed";
 const ASKI_CHAT_BANNER_URL = "https://aski.chat?utm_source=saas-template-sticky-banner";
@@ -123,6 +124,8 @@ function CollapseButton({ onCollapse }: CollapseButtonProps) {
 }
 
 function BannerContent() {
+  const t = useTranslations("Client.AskiChatBanner");
+
   return (
     <div className="flex items-center flex-col py-3 px-3">
       <a
@@ -132,14 +135,13 @@ function BannerContent() {
         className="flex flex-col items-center font-medium text-sm hover:text-foreground transition-colors"
       >
         <div className="flex items-center">
-          <span className="whitespace-nowrap">Built by</span>
+          <span className="whitespace-nowrap">{t("builtBy")}</span>
           <AskiChatLogo className="h-7 w-7 mx-1.5" />
-          <span className="whitespace-nowrap">Aski.Chat</span>
+          <span className="whitespace-nowrap">{t("brand")}</span>
         </div>
 
         <div className="text-tiny text-muted-foreground mt-3">
-          AI customer support agents that answer visitors, capture leads, and
-          surface customer intelligence from every conversation.
+          {t("description")}
         </div>
       </a>
       <a
@@ -148,7 +150,7 @@ function BannerContent() {
         rel="noreferrer"
         className={buttonVariants({ size: "sm", className: "mt-4" })}
       >
-        Start with Aski.Chat
+        {t("cta")}
       </a>
     </div>
   );

--- a/src/components/blog-card.tsx
+++ b/src/components/blog-card.tsx
@@ -1,4 +1,5 @@
 import Image from "next/image"
+import { getLocale, getTranslations } from "next-intl/server"
 import { Link } from "@/i18n/navigation"
 import { formatDate } from "@/utils/format-date"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
@@ -6,6 +7,7 @@ import { getInitials } from "@/utils/name-initials"
 import { CmsEntryTags } from "@/components/cms-entry-tags"
 import type { CmsCollectionListItem } from "@/lib/cms/entry"
 import { getValidDateOrNow } from "@/utils/cms-entry-dates"
+import { getAuthorDisplayName } from "@/utils/blog-author-url"
 
 type BlogCardProps = {
   entry: CmsCollectionListItem
@@ -13,11 +15,13 @@ type BlogCardProps = {
   showAuthor?: boolean
 }
 
-export function BlogCard({ entry, showTags = true, showAuthor = true }: BlogCardProps) {
+export async function BlogCard({ entry, showTags = true, showAuthor = true }: BlogCardProps) {
+  const locale = await getLocale()
+  const t = await getTranslations("Blog.AuthorDetail")
   const author = entry.createdByUser
   const authorName = author
-    ? [author.firstName, author.lastName].filter(Boolean).join(' ') || author.email || 'Unknown'
-    : 'Unknown'
+    ? getAuthorDisplayName(author, t("unknownAuthor"))
+    : t("unknownAuthor")
   const description = entry.seoDescription?.trim()
 
   const displayDate = getValidDateOrNow({ value: entry.createdAt })
@@ -49,7 +53,7 @@ export function BlogCard({ entry, showTags = true, showAuthor = true }: BlogCard
             dateTime={displayDate.toISOString()}
             className="font-mono text-xs uppercase tracking-wide text-muted-foreground"
           >
-            {formatDate(displayDate)}
+            {formatDate(displayDate, locale)}
           </time>
 
           <h2 className="mt-3 line-clamp-2 font-display text-xl font-semibold leading-snug text-foreground transition-colors group-hover:text-edge">

--- a/src/components/blog-pagination-server.tsx
+++ b/src/components/blog-pagination-server.tsx
@@ -1,6 +1,7 @@
 import { getBlogPagePath } from "@/lib/blog-routing"
 import { getPathname } from "@/i18n/navigation"
 import type { Locale } from "@/i18n/config"
+import { getTranslations } from "next-intl/server"
 import {
   Pagination,
   PaginationContent,
@@ -17,7 +18,8 @@ interface BlogPaginationServerProps {
   locale: Locale;
 }
 
-export function BlogPaginationServer({ currentPage, totalPages, locale }: BlogPaginationServerProps) {
+export async function BlogPaginationServer({ currentPage, totalPages, locale }: BlogPaginationServerProps) {
+  const t = await getTranslations({ locale, namespace: "Client.Pagination" });
   // `PaginationLink` renders a plain `<a href>`, so the href must already carry
   // any active locale prefix or pagination can drop the visitor's locale.
   const pageHref = (page: number) => getPathname({ href: getBlogPagePath({ page }), locale })
@@ -62,20 +64,28 @@ export function BlogPaginationServer({ currentPage, totalPages, locale }: BlogPa
 
 
   return (
-    <Pagination>
+    <Pagination ariaLabel={t("navAria")}>
       <PaginationContent>
         <PaginationItem>
           {currentPage === 1 ? (
-            <PaginationPrevious className="pointer-events-none opacity-50" />
+            <PaginationPrevious
+              className="pointer-events-none opacity-50"
+              label={t("previous")}
+              ariaLabel={t("previousAria")}
+            />
           ) : (
-            <PaginationPrevious href={pageHref(currentPage - 1)} />
+            <PaginationPrevious
+              href={pageHref(currentPage - 1)}
+              label={t("previous")}
+              ariaLabel={t("previousAria")}
+            />
           )}
         </PaginationItem>
 
         {pageNumbers().map((page, index) => (
           <PaginationItem key={index}>
             {page === 'ellipsis' ? (
-              <PaginationEllipsis />
+              <PaginationEllipsis label={t("morePages")} />
             ) : (
               <PaginationLink href={pageHref(page)} isActive={currentPage === page}>
                 {page}
@@ -86,9 +96,17 @@ export function BlogPaginationServer({ currentPage, totalPages, locale }: BlogPa
 
         <PaginationItem>
           {currentPage === totalPages ? (
-            <PaginationNext className="pointer-events-none opacity-50" />
+            <PaginationNext
+              className="pointer-events-none opacity-50"
+              label={t("next")}
+              ariaLabel={t("nextAria")}
+            />
           ) : (
-            <PaginationNext href={pageHref(currentPage + 1)} />
+            <PaginationNext
+              href={pageHref(currentPage + 1)}
+              label={t("next")}
+              ariaLabel={t("nextAria")}
+            />
           )}
         </PaginationItem>
       </PaginationContent>

--- a/src/components/content-table-of-contents-nav.tsx
+++ b/src/components/content-table-of-contents-nav.tsx
@@ -93,10 +93,12 @@ function TableOfContentsBranch({
 
 interface ContentTableOfContentsNavProps {
   nodes: TableOfContentsNode[];
+  ariaLabel: string;
 }
 
 export function ContentTableOfContentsNav({
   nodes,
+  ariaLabel,
 }: ContentTableOfContentsNavProps) {
   const orderedIds = useMemo(() => flattenTableOfContentsIds(nodes), [nodes]);
   const [activeId, setActiveId] = useState<string | null>(null);
@@ -174,7 +176,7 @@ export function ContentTableOfContentsNav({
     <nav
       ref={navRef}
       className="mt-4 max-h-[calc(100vh-6rem)] overflow-y-auto pr-3"
-      aria-label="On this page"
+      aria-label={ariaLabel}
     >
       <TableOfContentsBranch
         nodes={nodes}

--- a/src/components/email-verification-dialog.tsx
+++ b/src/components/email-verification-dialog.tsx
@@ -15,9 +15,10 @@ import { toast } from "sonner";
 import { useState } from "react";
 import { EMAIL_VERIFICATION_TOKEN_EXPIRATION_SECONDS } from "@/constants";
 import isProd from "@/utils/is-prod";
-import { usePathname } from "next/navigation";
+import { usePathname } from "@/i18n/navigation";
 import { Route } from "next";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { useTranslations } from "next-intl";
 
 const pagesToBypass: Route[] = [
   "/verify-email",
@@ -33,7 +34,9 @@ const pagesToBypass: Route[] = [
 export function EmailVerificationDialog() {
   const { session } = useSessionStore();
   const [lastVerificationEmailSentAt, setLastVerificationEmailSentAt] = useState<number | null>(null);
+  // Locale-stripped pathname so bypass matches work under `/es/...` prefixes.
   const pathname = usePathname();
+  const t = useTranslations("Client.Auth.EmailVerificationDialog");
 
   const { execute: sendVerification, status } = useAction(sendVerificationAction, {
     onError: ({ error }) => {
@@ -41,11 +44,11 @@ export function EmailVerificationDialog() {
       toast.error(error.serverError?.message);
     },
     onExecute: () => {
-      toast.loading("Sending verification email...");
+      toast.loading(t("toastSending"));
     },
     onSuccess: () => {
       toast.dismiss();
-      toast.success("Verification email sent");
+      toast.success(t("toastSent"));
       setLastVerificationEmailSentAt(Date.now());
     },
   });
@@ -62,25 +65,25 @@ export function EmailVerificationDialog() {
 
   const canSendAgain = !lastVerificationEmailSentAt || Date.now() - lastVerificationEmailSentAt > 60000; // 1 minute cooldown
   const isLoading = status === "executing";
+  const expirationHours = Math.floor(EMAIL_VERIFICATION_TOKEN_EXPIRATION_SECONDS / 3600);
 
   return (
     <Dialog open modal onOpenChange={(newState) => {
       if (newState === false) {
-        toast.warning("Please verify your email before you continue");
+        toast.warning(t("toastCloseWarning"));
       }
     }}>
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
-          <DialogTitle>Verify your email</DialogTitle>
+          <DialogTitle>{t("title")}</DialogTitle>
           <DialogDescription>
-            Please verify your email address to access all features. We sent a verification link to {session.user.email}.
-            The verification link will expire in {Math.floor(EMAIL_VERIFICATION_TOKEN_EXPIRATION_SECONDS / 3600)} hours.
+            {t("description", { email: session.user.email ?? "", hours: expirationHours })}
 
             {!isProd && (
               <Alert className="mt-4 mb-2">
-                <AlertTitle>Development mode</AlertTitle>
+                <AlertTitle>{t("devModeTitle")}</AlertTitle>
                 <AlertDescription>
-                  You can find the verification link in the console.
+                  {t("devModeDescription")}
                 </AlertDescription>
               </Alert>
             )}
@@ -92,10 +95,10 @@ export function EmailVerificationDialog() {
             disabled={isLoading || !canSendAgain}
           >
             {isLoading
-              ? "Sending..."
+              ? t("sending")
               : !canSendAgain
-                ? "Please wait 1 minute before sending again"
-                : "Send verification email again"}
+                ? t("cooldown")
+                : t("resend")}
           </Button>
         </div>
       </DialogContent>

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -13,6 +13,7 @@ import { Suspense } from "react";
 
 export async function Footer() {
   const t = await getTranslations("Footer");
+  const tGithub = await getTranslations("Client.GithubStars");
 
   return (
     <footer className="border-t dark:bg-muted/30 bg-muted/60 shadow">
@@ -60,7 +61,7 @@ export async function Footer() {
                   className="group text-muted-foreground transition-colors duration-300 ease-out hover:text-foreground"
                 >
                   <GithubIcon className="h-5 w-5 transition-transform duration-300 ease-out group-hover:scale-110 motion-reduce:transform-none" />
-                  <span className="sr-only">GitHub</span>
+                  <span className="sr-only">{tGithub("github")}</span>
                 </a>
                 <a
                   href="https://x.com/LubomirGeorg"

--- a/src/components/github-stars-badge.tsx
+++ b/src/components/github-stars-badge.tsx
@@ -1,5 +1,6 @@
 import { SiGithub as GithubIcon } from "@icons-pack/react-simple-icons";
 import { ArrowRight, Star } from "lucide-react";
+import { getLocale, getTranslations } from "next-intl/server";
 import { GITHUB_REPO_URL } from "@/constants";
 import { getGithubStars } from "@/utils/stats";
 import { cn } from "@/lib/utils";
@@ -17,6 +18,7 @@ const SIZES = {
     chip: "gap-2 px-3 py-1.5",
     chipIcon: "size-4",
     chipText: "text-[11px]",
+    chipSkeleton: "h-3 w-20",
     star: "size-5",
     count: "text-2xl",
     label: "text-[11px]",
@@ -28,6 +30,7 @@ const SIZES = {
     chip: "gap-1.5 px-2.5 py-1",
     chipIcon: "size-3.5",
     chipText: "text-[10px]",
+    chipSkeleton: "h-2.5 w-16",
     star: "size-4",
     count: "text-lg",
     label: "text-[10px]",
@@ -40,7 +43,11 @@ const PILL_BASE =
   "group inline-flex items-center rounded-full border border-edge/40 bg-edge/10 shadow-lg shadow-edge/10 transition-all duration-300 ease-out hover:-translate-y-0.5 hover:border-edge/70 hover:bg-edge/20 hover:shadow-xl hover:shadow-edge/25 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-edge focus-visible:ring-offset-2 focus-visible:ring-offset-background active:translate-y-0 active:scale-[0.98] motion-reduce:transition-none motion-reduce:hover:translate-y-0";
 
 export async function GithubStarsBadge({ size = "lg", className }: GithubStarsBadgeProps) {
-  const stars = await getGithubStars();
+  const [stars, t, locale] = await Promise.all([
+    getGithubStars(),
+    getTranslations("Client.GithubStars"),
+    getLocale(),
+  ]);
   const s = SIZES[size];
 
   return (
@@ -48,7 +55,7 @@ export async function GithubStarsBadge({ size = "lg", className }: GithubStarsBa
       href={GITHUB_REPO_URL}
       target="_blank"
       rel="noreferrer"
-      aria-label={stars ? `Star the repo on GitHub — ${stars} stars` : "Star the repo on GitHub"}
+      aria-label={stars ? t("starAriaWithCount", { count: stars }) : t("starAria")}
       className={cn(PILL_BASE, s.pill, className)}
     >
       <span className={cn("inline-flex items-center rounded-full bg-background/70", s.chip)}>
@@ -59,7 +66,7 @@ export async function GithubStarsBadge({ size = "lg", className }: GithubStarsBa
             s.chipText,
           )}
         >
-          star the repo
+          {t("starTheRepo")}
         </span>
       </span>
       <span className="flex items-center gap-2">
@@ -75,7 +82,7 @@ export async function GithubStarsBadge({ size = "lg", className }: GithubStarsBa
             s.count,
           )}
         >
-          {stars ? stars.toLocaleString() : "GitHub"}
+          {stars ? stars.toLocaleString(locale) : t("github")}
         </span>
         {stars ? (
           <span
@@ -84,7 +91,7 @@ export async function GithubStarsBadge({ size = "lg", className }: GithubStarsBa
               s.label,
             )}
           >
-            stars
+            {t("stars")}
           </span>
         ) : null}
       </span>
@@ -98,24 +105,16 @@ export async function GithubStarsBadge({ size = "lg", className }: GithubStarsBa
   );
 }
 
-export function GithubStarsBadgeFallback({
-  size = "lg",
-  className,
-}: GithubStarsBadgeProps) {
+// Skeletons only — no copy — so the Suspense fallback never flashes English
+// text on non-default locales (same rationale as DocsNavigationChromeFallback).
+export function GithubStarsBadgeFallback({ size = "lg", className }: GithubStarsBadgeProps) {
   const s = SIZES[size];
 
   return (
     <div className={cn(PILL_BASE, s.pill, "pointer-events-none", className)}>
       <span className={cn("inline-flex items-center rounded-full bg-background/70", s.chip)}>
         <GithubIcon className={cn("text-foreground", s.chipIcon)} />
-        <span
-          className={cn(
-            "font-mono font-medium uppercase tracking-wide text-muted-foreground",
-            s.chipText,
-          )}
-        >
-          star the repo
-        </span>
+        <span className={cn("animate-pulse rounded bg-foreground/10", s.chipSkeleton)} />
       </span>
       <span className="flex items-center gap-2">
         <Star className={cn("fill-edge text-edge", s.star)} />

--- a/src/components/locale-switcher.tsx
+++ b/src/components/locale-switcher.tsx
@@ -38,7 +38,11 @@ export default function LocaleSwitcher({ className }: LocaleSwitcherProps) {
       // The NextIntlClientProvider sits in the root layout (above [locale]) and is
       // shared across locales, so a soft navigation won't re-render it — useLocale()
       // and translations stay stale. Hard-navigate so it re-reads the new locale.
-      window.location.href = getPathname({ href: pathname, locale })
+      // usePathname() strips the query/hash, so re-append them (e.g. ?redirect= on sign-in).
+      window.location.href =
+        getPathname({ href: pathname, locale }) +
+        window.location.search +
+        window.location.hash
     })
   }
 

--- a/src/components/locale-switcher.tsx
+++ b/src/components/locale-switcher.tsx
@@ -23,7 +23,7 @@ interface LocaleSwitcherProps {
 
 export default function LocaleSwitcher({ className }: LocaleSwitcherProps) {
   const t = useTranslations("Client.LocaleSwitcher")
-  const activeLocale = useLocale() as Locale
+  const activeLocale = useLocale()
   const pathname = usePathname()
   const [isPending, startTransition] = React.useTransition()
 

--- a/src/components/nav-user.tsx
+++ b/src/components/nav-user.tsx
@@ -44,7 +44,7 @@ import { useSessionStore } from "@/state/session"
 import { useTheme } from "next-themes"
 import { useLocale, useTranslations } from "next-intl"
 import { cn } from "@/lib/utils"
-import { ENABLED_LOCALES, LOCALE_LABELS, type Locale } from "@/i18n/config"
+import { ENABLED_LOCALES, LOCALE_LABELS } from "@/i18n/config"
 import { LocaleFlag } from "@/components/locale-flag"
 import { useChangeLocale } from "@/hooks/useChangeLocale"
 import type { SessionValidationResult } from "@/types"
@@ -60,7 +60,7 @@ export function NavUser({ session: sessionProp }: NavUserProps) {
   const { isMobile, setOpenMobile } = useSidebar()
   const router = useRouter()
   const { setTheme } = useTheme()
-  const activeLocale = useLocale() as Locale
+  const activeLocale = useLocale()
   const { changeLocale } = useChangeLocale()
   const t = useTranslations("Client.Sidebar.user")
 

--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -2,7 +2,6 @@
 
 import NextLink from "next/link"
 import type { Route } from 'next'
-import { usePathname } from "next/navigation"
 import { useTranslations } from "next-intl"
 import { ComponentIcon, Menu } from 'lucide-react'
 import { Button, buttonVariants } from "@/components/ui/button"
@@ -14,7 +13,7 @@ import { Skeleton } from "@/components/ui/skeleton"
 import { SITE_NAME } from "@/constants"
 import { DOCS_BASE_PATH } from "@/lib/cms/docs-config"
 import { ROLES_ENUM } from "@/app/enums"
-import { Link } from "@/i18n/navigation"
+import { Link, usePathname } from "@/i18n/navigation"
 import LocaleSwitcher from "@/components/locale-switcher"
 
 type NavItem = {

--- a/src/components/team-switcher.tsx
+++ b/src/components/team-switcher.tsx
@@ -23,6 +23,8 @@ import { useSessionStore } from "@/state/session"
 import { useAction } from "next-safe-action/hooks"
 import { updateSelectedTeamAction } from "@/actions/session.action"
 import { toast } from "sonner"
+import { cn } from "@/lib/utils"
+import { useTranslations } from "next-intl"
 
 export function TeamSwitcher({
   teams,
@@ -34,6 +36,7 @@ export function TeamSwitcher({
     role: string
   }[]
 }) {
+  const t = useTranslations("Client.Dashboard.Teams")
   const { isMobile, setOpenMobile } = useSidebar()
   const session = useSessionStore()
   const selectedTeamId = session.selectedTeam()
@@ -44,7 +47,7 @@ export function TeamSwitcher({
       console.error("Failed to update selected team:", error);
       // Revert optimistic update
       setSelectedTeam(selectedTeamId);
-      toast.error(error.serverError?.message || "Failed to update selected team");
+      toast.error(error.serverError?.message || t("toastUpdateSelectedTeamError"));
     },
   })
 
@@ -84,9 +87,11 @@ export function TeamSwitcher({
               </div>
               <div className="grid flex-1 text-left text-sm leading-tight">
                 <span className="truncate font-semibold">
-                  {activeTeam?.name || "No Team"}
+                  {activeTeam?.name || t("switcherNoTeam")}
                 </span>
-                <span className="truncate text-xs capitalize">{activeTeam?.role || "Member"}</span>
+                <span className={cn("truncate text-xs", activeTeam?.role && "capitalize")}>
+                  {activeTeam?.role || t("memberRole")}
+                </span>
               </div>
               <ChevronsUpDown className="ml-auto" />
           </DropdownMenuTrigger>
@@ -97,7 +102,7 @@ export function TeamSwitcher({
             sideOffset={4}
           >
             <DropdownMenuLabel className="text-xs text-muted-foreground">
-              Teams
+              {t("switcherTeamsLabel")}
             </DropdownMenuLabel>
             {teams.length > 0 ? (
               teams.map((team, index) => (
@@ -119,7 +124,7 @@ export function TeamSwitcher({
                 <div className="flex size-6 items-center justify-center rounded-sm border">
                   <Building2 className="size-4 shrink-0" />
                 </div>
-                No teams available
+                {t("switcherNoTeams")}
               </DropdownMenuItem>
             )}
             <DropdownMenuSeparator />
@@ -136,7 +141,7 @@ export function TeamSwitcher({
                 <div className="flex size-6 items-center justify-center rounded-md border bg-background">
                   <Plus className="size-4" />
                 </div>
-                <div className="font-medium text-muted-foreground">Add team</div>
+                <div className="font-medium text-muted-foreground">{t("switcherAddTeam")}</div>
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>

--- a/src/components/teams/create-team-form.tsx
+++ b/src/components/teams/create-team-form.tsx
@@ -11,6 +11,7 @@ import { toast } from "sonner";
 import { useAction } from "next-safe-action/hooks";
 import { createTeamAction } from "@/actions/team-actions";
 import { encodeValidationMessage, maxString, requiredString, v, validationKey } from "@/lib/validation";
+import { useTranslations } from "next-intl";
 
 const formSchema = v.object({
   name: v.pipe(
@@ -42,17 +43,18 @@ function getCreatedTeamSlug(payload: CreateTeamPayload | undefined): string | un
 }
 
 export function CreateTeamForm() {
-  const { execute: createTeam } = useAction(createTeamAction, {
+  const t = useTranslations("Client.Dashboard.Teams");
+  const { execute: submitCreateTeam } = useAction(createTeamAction, {
     onError: ({ error }) => {
       toast.dismiss();
-      toast.error(error.serverError?.message || "Failed to create team");
+      toast.error(error.serverError?.message || t("toastCreateError"));
     },
     onExecute: () => {
-      toast.loading("Creating team...");
+      toast.loading(t("toastCreating"));
     },
     onSuccess: ({ data }) => {
       toast.dismiss();
-      toast.success("Team created successfully");
+      toast.success(t("toastCreateSuccess"));
 
       const teamSlug = getCreatedTeamSlug(data);
       const teamPath = teamSlug ? `/dashboard/teams/${teamSlug}` : "/dashboard/teams";
@@ -77,7 +79,7 @@ export function CreateTeamForm() {
       avatarUrl: data.avatarUrl || undefined
     };
 
-    createTeam(formData);
+    submitCreateTeam(formData);
   }
 
   return (
@@ -88,12 +90,12 @@ export function CreateTeamForm() {
           name="name"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>Team Name</FormLabel>
+              <FormLabel>{t("formNameLabel")}</FormLabel>
               <FormControl>
-                <Input placeholder="Enter team name" {...field} />
+                <Input placeholder={t("formNamePlaceholder")} {...field} />
               </FormControl>
               <FormDescription>
-                A unique name for your team
+                {t("formNameDescription")}
               </FormDescription>
               <FormMessage />
             </FormItem>
@@ -105,16 +107,16 @@ export function CreateTeamForm() {
           name="description"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>Description</FormLabel>
+              <FormLabel>{t("formDescriptionLabel")}</FormLabel>
               <FormControl>
                 <Textarea
-                  placeholder="Enter a brief description of your team"
+                  placeholder={t("formDescriptionPlaceholder")}
                   {...field}
                   value={field.value || ""}
                 />
               </FormControl>
               <FormDescription>
-                Optional description of your team&apos;s purpose
+                {t("formDescriptionHelp")}
               </FormDescription>
               <FormMessage />
             </FormItem>
@@ -122,7 +124,7 @@ export function CreateTeamForm() {
         />
 
         <Button type="submit" className="w-full">
-          Create Team
+          {t("createTeam")}
         </Button>
       </form>
     </Form>

--- a/src/components/teams/invite-member-modal.tsx
+++ b/src/components/teams/invite-member-modal.tsx
@@ -18,6 +18,7 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { requiredString, v, validationKey } from "@/lib/validation";
+import { useTranslations } from "next-intl";
 
 // Define the form schema with validation
 const formSchema = v.object({
@@ -33,6 +34,7 @@ interface InviteMemberModalProps {
 }
 
 export function InviteMemberModal({ teamId, trigger, onInviteSuccess }: InviteMemberModalProps) {
+  const t = useTranslations("Client.Dashboard.Teams");
   const [open, setOpen] = useState(false);
 
   // Initialize react-hook-form
@@ -46,15 +48,15 @@ export function InviteMemberModal({ teamId, trigger, onInviteSuccess }: InviteMe
   const { execute } = useAction(inviteUserAction, {
     onError: ({ error }) => {
       toast.dismiss();
-      toast.error(error.serverError?.message || "Failed to invite user");
+      toast.error(error.serverError?.message || t("toastInviteError"));
       console.error("Invite error:", error);
     },
     onExecute: () => {
-      toast.loading("Sending invitation...");
+      toast.loading(t("toastSendingInvite"));
     },
     onSuccess: () => {
       toast.dismiss();
-      toast.success("Invitation sent successfully");
+      toast.success(t("toastInviteSuccess"));
       form.reset();
 
       if (onInviteSuccess) {
@@ -82,7 +84,7 @@ export function InviteMemberModal({ teamId, trigger, onInviteSuccess }: InviteMe
       <DialogTrigger render={trigger} />
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
-          <DialogTitle>Invite Team Member</DialogTitle>
+          <DialogTitle>{t("inviteModalTitle")}</DialogTitle>
         </DialogHeader>
 
         <Form {...form}>
@@ -92,11 +94,11 @@ export function InviteMemberModal({ teamId, trigger, onInviteSuccess }: InviteMe
               name="email"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Email Address</FormLabel>
+                  <FormLabel>{t("inviteEmailLabel")}</FormLabel>
                   <FormControl>
                     <Input
                       type="email"
-                      placeholder="colleague@example.com"
+                      placeholder={t("inviteEmailPlaceholder")}
                       {...field}
                     />
                   </FormControl>
@@ -109,11 +111,11 @@ export function InviteMemberModal({ teamId, trigger, onInviteSuccess }: InviteMe
               <DialogClose
                 render={<Button type="button" variant="outline" />}
               >
-                Cancel
+                {t("cancel")}
               </DialogClose>
 
               <Button type="submit">
-                Send Invitation
+                {t("sendInvitation")}
               </Button>
             </div>
           </form>

--- a/src/components/teams/remove-member-button.tsx
+++ b/src/components/teams/remove-member-button.tsx
@@ -23,6 +23,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { useAction } from "next-safe-action/hooks";
+import { useTranslations } from "next-intl";
 
 interface RemoveMemberButtonProps {
   teamId: string;
@@ -37,18 +38,20 @@ export function RemoveMemberButton({
   userId,
   memberName,
   isDisabled = false,
-  tooltipText = "You cannot remove this member"
+  tooltipText,
 }: RemoveMemberButtonProps) {
+  const t = useTranslations("Client.Dashboard.Teams");
+  const resolvedTooltipText = tooltipText ?? t("cannotRemoveTooltip");
   const dialogCloseRef = useRef<HTMLButtonElement>(null);
   const router = useRouter();
 
   const { execute: removeMember, isExecuting } = useAction(removeTeamMemberAction, {
     onError: ({ error }) => {
-      toast.error(error.serverError?.message || "Failed to remove team member");
+      toast.error(error.serverError?.message || t("toastRemoveError"));
       dialogCloseRef.current?.click();
     },
     onSuccess: () => {
-      toast.success("Team member removed successfully");
+      toast.success(t("toastRemoveSuccess"));
       router.refresh();
       dialogCloseRef.current?.click();
     }
@@ -73,11 +76,11 @@ export function RemoveMemberButton({
                 disabled
             >
               <TrashIcon className="h-4 w-4" />
-              <span className="sr-only">Cannot remove member</span>
+              <span className="sr-only">{t("cannotRemoveMember")}</span>
               </Button>
           </TooltipTrigger>
           <TooltipContent side="left" sideOffset={5} className="text-sm font-medium">
-            {tooltipText}
+            {resolvedTooltipText}
           </TooltipContent>
         </Tooltip>
       </TooltipProvider>
@@ -96,13 +99,13 @@ export function RemoveMemberButton({
         }
       >
           <TrashIcon className="h-4 w-4" />
-          <span className="sr-only">Remove member</span>
+          <span className="sr-only">{t("removeMember")}</span>
       </DialogTrigger>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Remove team member</DialogTitle>
+          <DialogTitle>{t("removeMemberTitle")}</DialogTitle>
           <DialogDescription>
-            Are you sure you want to remove {memberName} from this team? This action cannot be undone.
+            {t("removeMemberDescription", { name: memberName })}
           </DialogDescription>
         </DialogHeader>
         <DialogFooter className="mt-4 flex flex-col gap-4 sm:flex-row">
@@ -110,7 +113,7 @@ export function RemoveMemberButton({
             ref={dialogCloseRef}
             render={<Button variant="outline" className="sm:w-auto w-full" />}
           >
-            Cancel
+            {t("cancel")}
           </DialogClose>
           <Button
             variant="destructive"
@@ -118,7 +121,7 @@ export function RemoveMemberButton({
             disabled={isExecuting}
             className="sm:w-auto w-full"
           >
-            {isExecuting ? "Removing..." : "Remove member"}
+            {isExecuting ? t("removing") : t("removeMember")}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/src/components/theme-switch.tsx
+++ b/src/components/theme-switch.tsx
@@ -11,6 +11,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
+import { useTranslations } from "next-intl"
 
 interface ThemeSwitchProps {
   children?: React.ReactNode
@@ -19,6 +20,7 @@ interface ThemeSwitchProps {
 
 export default function ThemeSwitch({ children, className }: ThemeSwitchProps) {
   const { setTheme } = useTheme()
+  const t = useTranslations("Client.ThemeSwitch")
 
   return (
     <DropdownMenu>
@@ -36,17 +38,17 @@ export default function ThemeSwitch({ children, className }: ThemeSwitchProps) {
             <Moon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
           </div>
           {children && <span className="ml-2">{children}</span>}
-          <span className="sr-only">Toggle theme</span>
+          <span className="sr-only">{t("toggle")}</span>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
         <DropdownMenuItem onClick={() => setTheme("system")}>
-          System default
+          {t("system")}
         </DropdownMenuItem>
         <DropdownMenuItem onClick={() => setTheme("light")}>
-          Light
+          {t("light")}
         </DropdownMenuItem>
         <DropdownMenuItem onClick={() => setTheme("dark")}>
-          Dark
+          {t("dark")}
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/src/components/ui/pagination.tsx
+++ b/src/components/ui/pagination.tsx
@@ -4,10 +4,20 @@ import { ChevronLeft, ChevronRight, MoreHorizontal } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { ButtonProps, buttonVariants } from "@/components/ui/button"
 
-const Pagination = ({ className, ...props }: React.ComponentProps<"nav">) => (
+// Labels are required (no English defaults) so callers must supply localized
+// copy; see BlogPaginationServer for the translated usage.
+type PaginationProps = React.ComponentProps<"nav"> & {
+  ariaLabel: string
+}
+
+const Pagination = ({
+  className,
+  ariaLabel,
+  ...props
+}: PaginationProps) => (
   <nav
     role="navigation"
-    aria-label="pagination"
+    aria-label={ariaLabel}
     className={cn("mx-auto flex w-full justify-center", className)}
     {...props}
   />
@@ -59,49 +69,62 @@ const PaginationLink = ({
 )
 PaginationLink.displayName = "PaginationLink"
 
+type PaginationNavButtonProps = React.ComponentProps<typeof PaginationLink> & {
+  label: string
+  ariaLabel: string
+}
+
 const PaginationPrevious = ({
   className,
+  label,
+  ariaLabel,
   ...props
-}: React.ComponentProps<typeof PaginationLink>) => (
+}: PaginationNavButtonProps) => (
   <PaginationLink
-    aria-label="Go to previous page"
+    aria-label={ariaLabel}
     size="default"
     className={cn("gap-1 pl-2.5", className)}
     {...props}
   >
     <ChevronLeft className="h-4 w-4" />
-    <span>Previous</span>
+    <span>{label}</span>
   </PaginationLink>
 )
 PaginationPrevious.displayName = "PaginationPrevious"
 
 const PaginationNext = ({
   className,
+  label,
+  ariaLabel,
   ...props
-}: React.ComponentProps<typeof PaginationLink>) => (
+}: PaginationNavButtonProps) => (
   <PaginationLink
-    aria-label="Go to next page"
+    aria-label={ariaLabel}
     size="default"
     className={cn("gap-1 pr-2.5", className)}
     {...props}
   >
-    <span>Next</span>
+    <span>{label}</span>
     <ChevronRight className="h-4 w-4" />
   </PaginationLink>
 )
 PaginationNext.displayName = "PaginationNext"
 
+type PaginationEllipsisProps = React.ComponentProps<"span"> & {
+  label: string
+}
+
 const PaginationEllipsis = ({
   className,
+  label,
   ...props
-}: React.ComponentProps<"span">) => (
+}: PaginationEllipsisProps) => (
   <span
-    aria-hidden
     className={cn("flex h-9 w-9 items-center justify-center", className)}
     {...props}
   >
-    <MoreHorizontal className="h-4 w-4" />
-    <span className="sr-only">More pages</span>
+    <MoreHorizontal aria-hidden className="h-4 w-4" />
+    <span className="sr-only">{label}</span>
   </span>
 )
 PaginationEllipsis.displayName = "PaginationEllipsis"

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -4,6 +4,7 @@ import * as React from "react"
 import { useRender } from "@base-ui/react/use-render"
 import { VariantProps, cva } from "class-variance-authority"
 import { PanelLeft } from "lucide-react"
+import { useTranslations } from "next-intl"
 
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
@@ -264,6 +265,7 @@ const SidebarTrigger = React.forwardRef<
   React.ComponentProps<typeof Button>
 >(({ className, onClick, ...props }, ref) => {
   const { toggleSidebar } = useSidebar()
+  const t = useTranslations("Client.Sidebar")
 
   return (
     <Button
@@ -279,7 +281,7 @@ const SidebarTrigger = React.forwardRef<
       {...props}
     >
       <PanelLeft />
-      <span className="sr-only">Toggle Sidebar</span>
+      <span className="sr-only">{t("toggle")}</span>
     </Button>
   )
 })
@@ -290,16 +292,17 @@ const SidebarRail = React.forwardRef<
   React.ComponentProps<"button">
 >(({ className, ...props }, ref) => {
   const { toggleSidebar } = useSidebar()
+  const t = useTranslations("Client.Sidebar")
 
   return (
     <button
       type="button"
       ref={ref}
       data-sidebar="rail"
-      aria-label="Toggle Sidebar"
+      aria-label={t("toggle")}
       tabIndex={-1}
       onClick={toggleSidebar}
-      title="Toggle Sidebar"
+      title={t("toggle")}
       className={cn(
         "absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] hover:after:bg-sidebar-border group-data-[side=left]:-right-4 group-data-[side=right]:left-0 sm:flex",
         "[[data-side=left]_&]:cursor-w-resize [[data-side=right]_&]:cursor-e-resize",

--- a/src/hooks/useSignOut.ts
+++ b/src/hooks/useSignOut.ts
@@ -1,12 +1,16 @@
 import { useSessionStore } from "@/state/session";
 import { signOutAction } from "@/actions/sign-out.action";
 import { toast } from "sonner";
+import { useLocale, useTranslations } from "next-intl";
+import { getPathname } from "@/i18n/navigation";
 
 const useSignOut = () => {
   const { clearSession } = useSessionStore();
+  const locale = useLocale();
+  const t = useTranslations("Client.Settings.Nav");
 
   const signOut = async () => {
-    const toastId = toast.loading("Signing out...");
+    const toastId = toast.loading(t("toastSigningOut"));
 
     try {
       const { serverError } = await signOutAction();
@@ -17,10 +21,12 @@ const useSignOut = () => {
 
       clearSession();
       toast.dismiss(toastId);
-      window.location.replace("/");
+      // Full reload on purpose (clears client state); keep the locale prefix
+      // so a Spanish user lands on /es without a middleware redirect hop.
+      window.location.replace(getPathname({ href: "/", locale }));
     } catch (error) {
       toast.dismiss(toastId);
-      toast.error(error instanceof Error ? error.message : "Failed to sign out");
+      toast.error(error instanceof Error ? error.message : t("toastSignOutError"));
     }
   };
 

--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -44,3 +44,15 @@ export const LOCALE_OG_MAP: Record<Locale, string> = {
   en: "en_US",
   es: "es_ES",
 };
+
+// Primary + alternate OpenGraph locales for the active app locale. Any page
+// that defines its own `openGraph` must spread this in: Next.js replaces the
+// layout's openGraph object wholesale, dropping the layout-provided locales.
+export function getOpenGraphLocales(locale: Locale) {
+  return {
+    locale: LOCALE_OG_MAP[locale],
+    alternateLocale: ENABLED_LOCALES.filter((l) => l !== locale).map(
+      (l) => LOCALE_OG_MAP[l],
+    ),
+  };
+}

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -146,6 +146,18 @@
         "toastInvalidToken": "Invalid verification token",
         "errorTokenNotFound": "Verification token not found or expired"
       },
+      "EmailVerificationDialog": {
+        "title": "Verify your email",
+        "description": "Please verify your email address to access all features. We sent a verification link to {email}. The verification link will expire in {hours, plural, =1 {1 hour} other {# hours}}.",
+        "devModeTitle": "Development mode",
+        "devModeDescription": "You can find the verification link in the console.",
+        "toastSending": "Sending verification email...",
+        "toastSent": "Verification email sent",
+        "toastCloseWarning": "Please verify your email before you continue",
+        "sending": "Sending...",
+        "cooldown": "Please wait 1 minute before sending again",
+        "resend": "Send verification email again"
+      },
       "TeamInvite": {
         "meta": {
           "title": "Accept Team Invitation",
@@ -204,6 +216,7 @@
       },
       "Navigation": {
         "heading": "Documentation",
+        "navAriaLabel": "Docs navigation",
         "searchButton": "Search docs",
         "browseDocs": "Browse docs",
         "llmsTxt": "llms.txt"
@@ -227,6 +240,7 @@
         "sectionFallbackDescription": "Browse pages in this section.",
         "section": "Section",
         "noChildPages": "No public child pages are available in this section yet.",
+        "groupListName": "{group} documentation",
         "previous": "Previous",
         "next": "Next",
         "onThisPage": "On This Page"
@@ -423,6 +437,7 @@
       "scheduledRequiresFuturePublishDate": "A future publish date is required for scheduled entries"
     },
     "Sidebar": {
+      "toggle": "Toggle Sidebar",
       "groups": {
         "platform": "Platform",
         "projects": "Projects"
@@ -513,7 +528,72 @@
         "pendingInvitationsDescription": "You have been invited to join the following teams",
         "invitedBy": "Invited by {name}",
         "accepting": "Accepting...",
-        "accept": "Accept"
+        "accept": "Accept",
+        "cancel": "Cancel",
+        "formNameLabel": "Team Name",
+        "formNamePlaceholder": "Enter team name",
+        "formNameDescription": "A unique name for your team",
+        "formDescriptionLabel": "Description",
+        "formDescriptionPlaceholder": "Enter a brief description of your team",
+        "formDescriptionHelp": "Optional description of your team's purpose",
+        "toastCreating": "Creating team...",
+        "toastCreateSuccess": "Team created successfully",
+        "toastCreateError": "Failed to create team",
+        "inviteModalTitle": "Invite Team Member",
+        "inviteEmailLabel": "Email Address",
+        "inviteEmailPlaceholder": "colleague@example.com",
+        "sendInvitation": "Send Invitation",
+        "toastSendingInvite": "Sending invitation...",
+        "toastInviteSuccess": "Invitation sent successfully",
+        "toastInviteError": "Failed to invite user",
+        "removeMemberTitle": "Remove team member",
+        "removeMemberDescription": "Are you sure you want to remove {name} from this team? This action cannot be undone.",
+        "removeMember": "Remove member",
+        "removing": "Removing...",
+        "cannotRemoveMember": "Cannot remove member",
+        "cannotRemoveTooltip": "You cannot remove this member",
+        "toastRemoveSuccess": "Team member removed successfully",
+        "toastRemoveError": "Failed to remove team member",
+        "switcherNoTeam": "No Team",
+        "switcherTeamsLabel": "Teams",
+        "switcherNoTeams": "No teams available",
+        "switcherAddTeam": "Add team",
+        "toastUpdateSelectedTeamError": "Failed to update selected team",
+        "errorCreateLimit": "You have reached the limit of {max} teams you can create.",
+        "errorSlugGeneration": "Could not generate a unique slug for the team",
+        "errorCouldNotCreate": "Could not create team",
+        "errorGetTeams": "Failed to get user teams",
+        "errorInvalidRole": "Invalid team role",
+        "errorOwnerViaInvite": "Team owners cannot be assigned through invitations",
+        "errorRoleNotFound": "Team role not found",
+        "errorNoPermissionAssignRole": "You don't have permission to assign this role",
+        "errorTeamPermissionRequired": "You don't have the required permission in this team",
+        "errorCannotAssignPermissions": "You cannot assign a role with permissions you do not have",
+        "errorMembershipNotFound": "Team membership not found",
+        "errorCannotRemoveOwner": "Cannot remove the team owner",
+        "errorInvalidEmail": "Invalid or disposable email address",
+        "errorTeamNotFound": "Team not found",
+        "errorAlreadyMember": "User is already a member of this team",
+        "errorUserJoinLimit": "This user has reached the limit of {max} teams they can join.",
+        "errorCouldNotCreateInvitation": "Could not create invitation",
+        "errorInvitationNotFound": "Invitation not found",
+        "errorInvitationExpired": "Invitation has expired",
+        "errorInvitationAlreadyAccepted": "Invitation has already been accepted",
+        "errorInvitationWrongEmail": "This invitation is for a different email address",
+        "errorAlreadyOnTeam": "You are already a member of this team",
+        "errorJoinLimit": "You have reached the limit of {max} teams you can join.",
+        "errorMustBeLoggedIn": "You must be logged in to update your selected team",
+        "errorTeamNotFoundOrNotMember": "Team not found or you are not a member",
+        "errorUpdateSelectedTeam": "Failed to update selected team",
+        "errorGetPendingInvitations": "Failed to get pending team invitations",
+        "errorAcceptInvitation": "Failed to accept invitation",
+        "teamFallbackName": "Team",
+        "teamOwnerFallback": "Team Owner",
+        "roleOwner": "Owner",
+        "roleAdmin": "Admin",
+        "roleMember": "Member",
+        "roleGuest": "Guest",
+        "roleCustom": "Custom Role"
       },
       "Billing": {
         "breadcrumbDashboard": "Dashboard",
@@ -642,7 +722,9 @@
         "signOut": "Sign out",
         "signOutConfirmTitle": "Sign out?",
         "signOutConfirmDescription": "Are you sure you want to sign out of your account?",
-        "cancel": "Cancel"
+        "cancel": "Cancel",
+        "toastSigningOut": "Signing out...",
+        "toastSignOutError": "Failed to sign out"
       },
       "Profile": {
         "cardTitle": "Profile Settings",
@@ -702,6 +784,9 @@
         "unknownLocation": "Unknown location",
         "currentSessionBadge": "Current Session",
         "authenticatedWith": "Authenticated with {method}",
+        "authMethodPassword": "Password",
+        "authMethodPasskey": "Passkey",
+        "authMethodGoogleOauth": "Google",
         "deviceDescription": "{browserName} {browserVersion} on {deviceVendor} {deviceModel} {deviceType} ({osName} {osVersion})",
         "unknownBrowser": "Unknown browser",
         "unknownVersion": "Unknown version",
@@ -721,7 +806,38 @@
     "Errors": {
       "unexpected": "An unexpected error occurred",
       "notAuthenticated": "Not authenticated",
-      "userNotFound": "User not found"
+      "notAuthorized": "Not authorized",
+      "emailVerificationRequired": "Please verify your email first",
+      "userNotFound": "User not found",
+      "invalidInput": "Invalid input",
+      "rateLimitExceeded": "Rate limit exceeded. Try again in {minutes, plural, =1 {1 minute} other {# minutes}}."
+    },
+    "Pagination": {
+      "navAria": "Pagination",
+      "previous": "Previous",
+      "next": "Next",
+      "previousAria": "Go to previous page",
+      "nextAria": "Go to next page",
+      "morePages": "More pages"
+    },
+    "ThemeSwitch": {
+      "toggle": "Toggle theme",
+      "system": "System default",
+      "light": "Light",
+      "dark": "Dark"
+    },
+    "AskiChatBanner": {
+      "builtBy": "Built by",
+      "brand": "Aski.Chat",
+      "description": "AI customer support agents that answer visitors, capture leads, and surface customer intelligence from every conversation.",
+      "cta": "Start with Aski.Chat"
+    },
+    "GithubStars": {
+      "starTheRepo": "star the repo",
+      "stars": "stars",
+      "github": "GitHub",
+      "starAria": "Star the repo on GitHub",
+      "starAriaWithCount": "Star the repo on GitHub — {count} stars"
     }
   },
   "Legal": {
@@ -837,6 +953,7 @@
         "description": "Browse blog posts by {name}",
         "notFound": "Author Not Found"
       },
+      "unknownAuthor": "Unknown Author",
       "backToAuthors": "← Back to all authors",
       "postCount": "{count, plural, =1 {1 post} other {# posts}}"
     },

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -146,6 +146,18 @@
         "toastInvalidToken": "Token de verificación no válido",
         "errorTokenNotFound": "Token de verificación no encontrado o expirado"
       },
+      "EmailVerificationDialog": {
+        "title": "Verifica tu correo",
+        "description": "Verifica tu dirección de correo para acceder a todas las funciones. Enviamos un enlace de verificación a {email}. El enlace caducará en {hours, plural, =1 {1 hora} other {# horas}}.",
+        "devModeTitle": "Modo de desarrollo",
+        "devModeDescription": "Puedes encontrar el enlace de verificación en la consola.",
+        "toastSending": "Enviando correo de verificación...",
+        "toastSent": "Correo de verificación enviado",
+        "toastCloseWarning": "Verifica tu correo antes de continuar",
+        "sending": "Enviando...",
+        "cooldown": "Espera 1 minuto antes de volver a enviar",
+        "resend": "Enviar de nuevo el correo de verificación"
+      },
       "TeamInvite": {
         "meta": {
           "title": "Aceptar invitación al equipo",
@@ -204,6 +216,7 @@
       },
       "Navigation": {
         "heading": "Documentación",
+        "navAriaLabel": "Navegación de documentación",
         "searchButton": "Buscar docs",
         "browseDocs": "Explorar documentación",
         "llmsTxt": "llms.txt"
@@ -227,6 +240,7 @@
         "sectionFallbackDescription": "Explora las páginas de esta sección.",
         "section": "Sección",
         "noChildPages": "Todavía no hay páginas secundarias públicas disponibles en esta sección.",
+        "groupListName": "Documentación de {group}",
         "previous": "Anterior",
         "next": "Siguiente",
         "onThisPage": "En esta página"
@@ -423,6 +437,7 @@
       "scheduledRequiresFuturePublishDate": "Se requiere una fecha de publicación futura para las entradas programadas"
     },
     "Sidebar": {
+      "toggle": "Mostrar u ocultar la barra lateral",
       "groups": {
         "platform": "Plataforma",
         "projects": "Proyectos"
@@ -513,7 +528,72 @@
         "pendingInvitationsDescription": "Te han invitado a unirte a los siguientes equipos",
         "invitedBy": "Invitado por {name}",
         "accepting": "Aceptando...",
-        "accept": "Aceptar"
+        "accept": "Aceptar",
+        "cancel": "Cancelar",
+        "formNameLabel": "Nombre del equipo",
+        "formNamePlaceholder": "Introduce el nombre del equipo",
+        "formNameDescription": "Un nombre único para tu equipo",
+        "formDescriptionLabel": "Descripción",
+        "formDescriptionPlaceholder": "Introduce una breve descripción de tu equipo",
+        "formDescriptionHelp": "Descripción opcional del propósito de tu equipo",
+        "toastCreating": "Creando equipo...",
+        "toastCreateSuccess": "Equipo creado correctamente",
+        "toastCreateError": "No se pudo crear el equipo",
+        "inviteModalTitle": "Invitar miembro del equipo",
+        "inviteEmailLabel": "Correo electrónico",
+        "inviteEmailPlaceholder": "colega@ejemplo.com",
+        "sendInvitation": "Enviar invitación",
+        "toastSendingInvite": "Enviando invitación...",
+        "toastInviteSuccess": "Invitación enviada correctamente",
+        "toastInviteError": "No se pudo invitar al usuario",
+        "removeMemberTitle": "Eliminar miembro del equipo",
+        "removeMemberDescription": "¿Seguro que quieres eliminar a {name} de este equipo? Esta acción no se puede deshacer.",
+        "removeMember": "Eliminar miembro",
+        "removing": "Eliminando...",
+        "cannotRemoveMember": "No se puede eliminar al miembro",
+        "cannotRemoveTooltip": "No puedes eliminar a este miembro",
+        "toastRemoveSuccess": "Miembro del equipo eliminado correctamente",
+        "toastRemoveError": "No se pudo eliminar al miembro del equipo",
+        "switcherNoTeam": "Sin equipo",
+        "switcherTeamsLabel": "Equipos",
+        "switcherNoTeams": "No hay equipos disponibles",
+        "switcherAddTeam": "Añadir equipo",
+        "toastUpdateSelectedTeamError": "No se pudo actualizar el equipo seleccionado",
+        "errorCreateLimit": "Has alcanzado el límite de {max} equipos que puedes crear.",
+        "errorSlugGeneration": "No se pudo generar un slug único para el equipo",
+        "errorCouldNotCreate": "No se pudo crear el equipo",
+        "errorGetTeams": "No se pudieron obtener tus equipos",
+        "errorInvalidRole": "Rol de equipo no válido",
+        "errorOwnerViaInvite": "Los propietarios del equipo no se pueden asignar mediante invitaciones",
+        "errorRoleNotFound": "Rol de equipo no encontrado",
+        "errorNoPermissionAssignRole": "No tienes permiso para asignar este rol",
+        "errorTeamPermissionRequired": "No tienes el permiso requerido en este equipo",
+        "errorCannotAssignPermissions": "No puedes asignar un rol con permisos que no tienes",
+        "errorMembershipNotFound": "Membresía del equipo no encontrada",
+        "errorCannotRemoveOwner": "No se puede eliminar al propietario del equipo",
+        "errorInvalidEmail": "Dirección de correo electrónico no válida o desechable",
+        "errorTeamNotFound": "Equipo no encontrado",
+        "errorAlreadyMember": "El usuario ya es miembro de este equipo",
+        "errorUserJoinLimit": "Este usuario ha alcanzado el límite de {max} equipos a los que puede unirse.",
+        "errorCouldNotCreateInvitation": "No se pudo crear la invitación",
+        "errorInvitationNotFound": "Invitación no encontrada",
+        "errorInvitationExpired": "La invitación ha caducado",
+        "errorInvitationAlreadyAccepted": "La invitación ya ha sido aceptada",
+        "errorInvitationWrongEmail": "Esta invitación es para una dirección de correo diferente",
+        "errorAlreadyOnTeam": "Ya eres miembro de este equipo",
+        "errorJoinLimit": "Has alcanzado el límite de {max} equipos a los que puedes unirte.",
+        "errorMustBeLoggedIn": "Debes iniciar sesión para actualizar el equipo seleccionado",
+        "errorTeamNotFoundOrNotMember": "Equipo no encontrado o no eres miembro",
+        "errorUpdateSelectedTeam": "No se pudo actualizar el equipo seleccionado",
+        "errorGetPendingInvitations": "No se pudieron obtener las invitaciones pendientes",
+        "errorAcceptInvitation": "No se pudo aceptar la invitación",
+        "teamFallbackName": "Equipo",
+        "teamOwnerFallback": "Propietario del equipo",
+        "roleOwner": "Propietario",
+        "roleAdmin": "Administrador",
+        "roleMember": "Miembro",
+        "roleGuest": "Invitado",
+        "roleCustom": "Rol personalizado"
       },
       "Billing": {
         "breadcrumbDashboard": "Panel",
@@ -642,7 +722,9 @@
         "signOut": "Cerrar sesión",
         "signOutConfirmTitle": "¿Cerrar sesión?",
         "signOutConfirmDescription": "¿Seguro que quieres cerrar la sesión de tu cuenta?",
-        "cancel": "Cancelar"
+        "cancel": "Cancelar",
+        "toastSigningOut": "Cerrando sesión...",
+        "toastSignOutError": "No se pudo cerrar la sesión"
       },
       "Profile": {
         "cardTitle": "Ajustes del perfil",
@@ -702,6 +784,9 @@
         "unknownLocation": "Ubicación desconocida",
         "currentSessionBadge": "Sesión actual",
         "authenticatedWith": "Autenticado con {method}",
+        "authMethodPassword": "Contraseña",
+        "authMethodPasskey": "Passkey",
+        "authMethodGoogleOauth": "Google",
         "deviceDescription": "{browserName} {browserVersion} en {deviceVendor} {deviceModel} {deviceType} ({osName} {osVersion})",
         "unknownBrowser": "Navegador desconocido",
         "unknownVersion": "Versión desconocida",
@@ -721,7 +806,38 @@
     "Errors": {
       "unexpected": "Ocurrió un error inesperado",
       "notAuthenticated": "No autenticado",
-      "userNotFound": "Usuario no encontrado"
+      "notAuthorized": "No autorizado",
+      "emailVerificationRequired": "Primero verifica tu correo electrónico",
+      "userNotFound": "Usuario no encontrado",
+      "invalidInput": "Entrada no válida",
+      "rateLimitExceeded": "Se ha superado el límite de solicitudes. Inténtalo de nuevo en {minutes, plural, =1 {1 minuto} other {# minutos}}."
+    },
+    "Pagination": {
+      "navAria": "Paginación",
+      "previous": "Anterior",
+      "next": "Siguiente",
+      "previousAria": "Ir a la página anterior",
+      "nextAria": "Ir a la página siguiente",
+      "morePages": "Más páginas"
+    },
+    "ThemeSwitch": {
+      "toggle": "Cambiar tema",
+      "system": "Predeterminado del sistema",
+      "light": "Claro",
+      "dark": "Oscuro"
+    },
+    "AskiChatBanner": {
+      "builtBy": "Hecho por",
+      "brand": "Aski.Chat",
+      "description": "Agentes de atención al cliente con IA que responden a los visitantes, capturan leads y obtienen inteligencia de cliente de cada conversación.",
+      "cta": "Empieza con Aski.Chat"
+    },
+    "GithubStars": {
+      "starTheRepo": "dar estrella al repo",
+      "stars": "estrellas",
+      "github": "GitHub",
+      "starAria": "Dar estrella al repositorio en GitHub",
+      "starAriaWithCount": "Dar estrella al repositorio en GitHub — {count} estrellas"
     }
   },
   "Legal": {
@@ -837,6 +953,7 @@
         "description": "Explora las entradas del blog de {name}",
         "notFound": "Autor no encontrado"
       },
+      "unknownAuthor": "Autor desconocido",
       "backToAuthors": "← Volver a todos los autores",
       "postCount": "{count, plural, =1 {1 entrada} other {# entradas}}"
     },

--- a/src/i18n/navigation.ts
+++ b/src/i18n/navigation.ts
@@ -4,10 +4,12 @@ import type { Locale } from "./config";
 import { routing } from "./routing";
 
 // Only the consumed helpers are re-exported (the linter rejects unused exports).
-// `redirect`/`permanentRedirect` preserve the active locale prefix on blog/docs and
-// CMS redirects; `Link`/`getPathname` keep it on internal links and hreflang URLs.
+// `redirect`/`permanentRedirect`/`useRouter` preserve the active locale prefix on
+// blog/docs and CMS redirects; `Link`/`getPathname`/`usePathname` keep it on
+// internal links, hreflang URLs, and active-path matching.
 const {
   usePathname,
+  useRouter,
   getPathname,
   Link,
   redirect: intlRedirect,
@@ -30,4 +32,4 @@ function permanentRedirect(args: LocalizedRedirectArgs): never {
   return intlPermanentRedirect(args as never);
 }
 
-export { usePathname, getPathname, Link, redirect, permanentRedirect };
+export { usePathname, useRouter, getPathname, Link, redirect, permanentRedirect };

--- a/src/lib/action-error.ts
+++ b/src/lib/action-error.ts
@@ -1,8 +1,47 @@
+import type { Messages } from "next-intl";
+
+// Dotted path to every string leaf of the message catalog, e.g.
+// "Client.Dashboard.Teams.errorJoinLimit". Non-string leaves (arrays used via
+// `t.raw`) are excluded — they can't be error messages.
+type LeafPaths<T> = {
+  [K in keyof T & string]: T[K] extends string
+    ? K
+    : T[K] extends readonly unknown[]
+      ? never
+      : `${K}.${LeafPaths<T[K]>}`;
+}[keyof T & string];
+
+export type ActionErrorMessageKey = LeafPaths<Messages>;
+
+export type ActionErrorMessageParams = Record<string, string | number>;
+
+interface ActionErrorKeyedMessage {
+  key: ActionErrorMessageKey;
+  params?: ActionErrorMessageParams;
+}
+
+export type ActionErrorMessage = string | ActionErrorKeyedMessage;
+
+// Prefer the `(code, { key, params })` form: throw sites stay free of
+// translation (and stay sync); `actionClient` translates the key once in
+// `handleServerError` and surfaces it to clients as a stable `reason` for
+// branching. The plain-string form remains for messages translated at the
+// throw site (legacy convention) — those pass through untranslated.
 export class ActionError extends Error {
   readonly code: string;
+  readonly messageKey?: ActionErrorMessageKey;
+  readonly messageParams?: ActionErrorMessageParams;
 
-  constructor(code: string, message: string) {
-    super(message);
+  constructor(code: string, message: ActionErrorMessage) {
+    if (typeof message === "string") {
+      super(message);
+    } else {
+      // `Error.message` holds the raw key (+ params) for server logs; the
+      // user-facing translation happens in `handleServerError`.
+      super(message.params ? `${message.key} ${JSON.stringify(message.params)}` : message.key);
+      this.messageKey = message.key;
+      this.messageParams = message.params;
+    }
     this.name = "ActionError";
     this.code = code;
   }

--- a/src/lib/safe-action.ts
+++ b/src/lib/safe-action.ts
@@ -2,30 +2,55 @@ import "server-only";
 
 import { createSafeActionClient } from "next-safe-action";
 import { getTranslations } from "next-intl/server";
-import { ActionError } from "@/lib/action-error";
+import { ActionError, type ActionErrorMessageKey, type ActionErrorMessageParams } from "@/lib/action-error";
 import { translateValidationKey } from "@/lib/validation-messages";
 import { RateLimitError } from "@/utils/with-rate-limit";
 
+interface ActionServerError {
+  code: string;
+  message: string;
+  // Stable catalog key of keyed ActionErrors, so clients can branch on the
+  // error's identity instead of matching localized message text.
+  reason?: ActionErrorMessageKey;
+}
+
+// next-intl can't type-check runtime-built keys; `ActionErrorMessageKey`
+// already guarantees a valid catalog path at the throw site.
+async function translateErrorKey(
+  key: ActionErrorMessageKey,
+  params?: ActionErrorMessageParams,
+): Promise<string> {
+  const t = await getTranslations();
+  return (t as (key: string, params?: ActionErrorMessageParams) => string)(key, params);
+}
+
 const baseActionClient = createSafeActionClient({
-  handleServerError(error) {
+  async handleServerError(error): Promise<ActionServerError> {
     if (error instanceof ActionError) {
       return {
         code: error.code,
-        message: error.message,
+        message: error.messageKey
+          ? await translateErrorKey(error.messageKey, error.messageParams)
+          : error.message,
+        reason: error.messageKey,
       };
     }
 
     if (error instanceof RateLimitError) {
+      const t = await getTranslations("Client.Errors");
       return {
         code: "RATE_LIMITED",
-        message: error.message,
+        message: t("rateLimitExceeded", {
+          minutes: Math.ceil(error.retryAfterSeconds / 60),
+        }),
       };
     }
 
     console.error("Safe action error:", error);
+    const t = await getTranslations("Client.Errors");
     return {
       code: "INTERNAL_SERVER_ERROR",
-      message: "Something went wrong",
+      message: t("unexpected"),
     };
   },
 });
@@ -46,9 +71,10 @@ export const actionClient = baseActionClient.use(async ({ next }) => {
 
 async function getValidationErrorMessage(validationErrors: unknown): Promise<string> {
   const messages = collectValidationMessages(validationErrors);
+  const tErrors = await getTranslations("Client.Errors");
 
   if (messages.length === 0) {
-    return "Invalid input";
+    return tErrors("invalidInput");
   }
 
   // Valibot messages set via src/lib/validation.ts are stable `Validation.*` keys;

--- a/src/lib/teams/team-members.ts
+++ b/src/lib/teams/team-members.ts
@@ -42,7 +42,7 @@ function getSystemRolePermissions(roleId: string): string[] {
     ];
   }
 
-  throw new ActionError("BAD_REQUEST", "Invalid team role");
+  throw new ActionError("BAD_REQUEST", { key: "Client.Dashboard.Teams.errorInvalidRole" });
 }
 
 async function resolveInvitationRole({
@@ -58,7 +58,7 @@ async function resolveInvitationRole({
 }): Promise<ResolvedInvitationRole> {
   if (isSystemRole) {
     if (roleId === SYSTEM_ROLES_ENUM.OWNER) {
-      throw new ActionError("FORBIDDEN", "Team owners cannot be assigned through invitations");
+      throw new ActionError("FORBIDDEN", { key: "Client.Dashboard.Teams.errorOwnerViaInvite" });
     }
 
     return {
@@ -76,7 +76,7 @@ async function resolveInvitationRole({
   });
 
   if (!role) {
-    throw new ActionError("NOT_FOUND", "Team role not found");
+    throw new ActionError("NOT_FOUND", { key: "Client.Dashboard.Teams.errorRoleNotFound" });
   }
 
   return {
@@ -105,13 +105,13 @@ function requirePermissionToAssignRole({
     || permissions.has(TEAM_PERMISSIONS.CHANGE_MEMBER_ROLES);
 
   if (!canAssignRoles) {
-    throw new ActionError("FORBIDDEN", "You don't have permission to assign this role");
+    throw new ActionError("FORBIDDEN", { key: "Client.Dashboard.Teams.errorNoPermissionAssignRole" });
   }
 
   const canGrantRolePermissions = role.permissions.every((permission) => permissions.has(permission));
 
   if (!canGrantRolePermissions) {
-    throw new ActionError("FORBIDDEN", "You cannot assign a role with permissions you do not have");
+    throw new ActionError("FORBIDDEN", { key: "Client.Dashboard.Teams.errorCannotAssignPermissions" });
   }
 }
 
@@ -143,16 +143,9 @@ export const getTeamMembers = cache(async (teamId: string) => {
   const roleMap = new Map(teamRoles.map(role => [role.id, role.name]));
 
   return Promise.all(members.map(async member => {
-    let roleName = "Unknown";
-
-    // For system roles, use the roleId directly as the name
-    if (member.isSystemRole) {
-      // Capitalize the first letter for display
-      roleName = member.roleId.charAt(0).toUpperCase() + member.roleId.slice(1);
-    } else {
-      // For custom roles, look up the name in our roleMap
-      roleName = roleMap.get(member.roleId) || "Custom Role";
-    }
+    // Custom roles carry their user-defined name; system roles return null and
+    // get a localized label at the render site from `roleId` + `isSystemRole`.
+    const roleName = member.isSystemRole ? null : (roleMap.get(member.roleId) ?? null);
 
     return {
       id: member.id,
@@ -192,12 +185,12 @@ export async function removeTeamMember({
   });
 
   if (!membership) {
-    throw new ActionError("NOT_FOUND", "Team membership not found");
+    throw new ActionError("NOT_FOUND", { key: "Client.Dashboard.Teams.errorMembershipNotFound" });
   }
 
   // Don't allow removing an owner
   if (membership.roleId === SYSTEM_ROLES_ENUM.OWNER && membership.isSystemRole) {
-    throw new ActionError("FORBIDDEN", "Cannot remove the team owner");
+    throw new ActionError("FORBIDDEN", { key: "Client.Dashboard.Teams.errorCannotRemoveOwner" });
   }
 
   await db.delete(teamMembershipTable)
@@ -227,7 +220,7 @@ export async function inviteUserToTeam({
   const session = await requireTeamPermission(teamId, TEAM_PERMISSIONS.INVITE_MEMBERS);
 
   if (!session) {
-    throw new ActionError("NOT_AUTHORIZED", "Not authenticated");
+    throw new ActionError("NOT_AUTHORIZED", { key: "Client.Errors.notAuthenticated" });
   }
 
   try {
@@ -236,7 +229,7 @@ export async function inviteUserToTeam({
     if (error instanceof ActionError) {
       throw error;
     }
-    throw new ActionError("ERROR", "Invalid or disposable email address");
+    throw new ActionError("ERROR", { key: "Client.Dashboard.Teams.errorInvalidEmail" });
   }
 
   const db = getDB();
@@ -258,7 +251,7 @@ export async function inviteUserToTeam({
   });
 
   if (!team) {
-    throw new ActionError("NOT_FOUND", "Team not found");
+    throw new ActionError("NOT_FOUND", { key: "Client.Dashboard.Teams.errorTeamNotFound" });
   }
 
   // Seat-cap gate: enforce the team plan's seat limit at this grow point. Counts current
@@ -288,11 +281,15 @@ export async function inviteUserToTeam({
   const seatsInUse = (memberCountResult[0]?.value || 0) + (pendingInvitesResult[0]?.value || 0);
 
   if (seatsInUse >= limits.seats) {
-    const t = await getTranslations("Client.Dashboard.Teams");
-    throw new ActionError("FORBIDDEN", t("seatLimitReached", { seats: limits.seats }));
+    throw new ActionError("FORBIDDEN", {
+      key: "Client.Dashboard.Teams.seatLimitReached",
+      params: { seats: limits.seats },
+    });
   }
 
-  const teamName = team.name as string || "Team";
+  // Email content (not an error): translated here, in the inviter's request locale.
+  const t = await getTranslations("Client.Dashboard.Teams");
+  const teamName = team.name as string || t("teamFallbackName");
 
   const inviter = {
     firstName: session.user.firstName || "",
@@ -318,7 +315,7 @@ export async function inviteUserToTeam({
     });
 
     if (existingMembership) {
-      throw new ActionError("CONFLICT", "User is already a member of this team");
+      throw new ActionError("CONFLICT", { key: "Client.Dashboard.Teams.errorAlreadyMember" });
     }
 
     const teamsCountResult = await db.select({ value: count() })
@@ -328,7 +325,10 @@ export async function inviteUserToTeam({
     const teamsJoined = teamsCountResult[0]?.value || 0;
 
     if (teamsJoined >= MAX_TEAMS_JOINED_PER_USER) {
-      throw new ActionError("FORBIDDEN", `This user has reached the limit of ${MAX_TEAMS_JOINED_PER_USER} teams they can join.`);
+      throw new ActionError("FORBIDDEN", {
+        key: "Client.Dashboard.Teams.errorUserJoinLimit",
+        params: { max: MAX_TEAMS_JOINED_PER_USER },
+      });
     }
 
     // User exists but is not a member, add them directly
@@ -383,7 +383,7 @@ export async function inviteUserToTeam({
       email,
       invitationToken: token,
       teamName,
-      inviterName: inviter.fullName || "Team Owner",
+      inviterName: inviter.fullName || t("teamOwnerFallback"),
       locale: inviterLocale,
     });
 
@@ -407,7 +407,7 @@ export async function inviteUserToTeam({
   const invitation = newInvitation?.[0];
 
   if (!invitation) {
-    throw new ActionError("ERROR", "Could not create invitation");
+    throw new ActionError("ERROR", { key: "Client.Dashboard.Teams.errorCouldNotCreateInvitation" });
   }
 
   // Send invitation email
@@ -415,7 +415,7 @@ export async function inviteUserToTeam({
     email,
     invitationToken: token,
     teamName,
-    inviterName: inviter.fullName || "Team Owner",
+    inviterName: inviter.fullName || t("teamOwnerFallback"),
     locale: inviterLocale,
   });
 
@@ -430,7 +430,7 @@ export async function acceptTeamInvitation(token: string) {
   const session = await getSessionFromCookie();
 
   if (!session) {
-    throw new ActionError("NOT_AUTHORIZED", "Not authenticated");
+    throw new ActionError("NOT_AUTHORIZED", { key: "Client.Errors.notAuthenticated" });
   }
 
   const db = getDB();
@@ -441,19 +441,19 @@ export async function acceptTeamInvitation(token: string) {
   });
 
   if (!invitation) {
-    throw new ActionError("NOT_FOUND", "Invitation not found");
+    throw new ActionError("NOT_FOUND", { key: "Client.Dashboard.Teams.errorInvitationNotFound" });
   }
 
   if (invitation.expiresAt && new Date(invitation.expiresAt) < new Date()) {
-    throw new ActionError("ERROR", "Invitation has expired");
+    throw new ActionError("ERROR", { key: "Client.Dashboard.Teams.errorInvitationExpired" });
   }
 
   if (invitation.acceptedAt) {
-    throw new ActionError("CONFLICT", "Invitation has already been accepted");
+    throw new ActionError("CONFLICT", { key: "Client.Dashboard.Teams.errorInvitationAlreadyAccepted" });
   }
 
   if (session.user.email !== invitation.email) {
-    throw new ActionError("FORBIDDEN", "This invitation is for a different email address");
+    throw new ActionError("FORBIDDEN", { key: "Client.Dashboard.Teams.errorInvitationWrongEmail" });
   }
 
   const existingMembership = await db.query.teamMembershipTable.findFirst({
@@ -473,7 +473,7 @@ export async function acceptTeamInvitation(token: string) {
       })
       .where(eq(teamInvitationTable.id, invitation.id));
 
-    throw new ActionError("CONFLICT", "You are already a member of this team");
+    throw new ActionError("CONFLICT", { key: "Client.Dashboard.Teams.errorAlreadyOnTeam" });
   }
 
   const teamsCountResult = await db.select({ value: count() })
@@ -483,7 +483,10 @@ export async function acceptTeamInvitation(token: string) {
   const teamsJoined = teamsCountResult[0]?.value || 0;
 
   if (teamsJoined >= MAX_TEAMS_JOINED_PER_USER) {
-    throw new ActionError("FORBIDDEN", `You have reached the limit of ${MAX_TEAMS_JOINED_PER_USER} teams you can join.`);
+    throw new ActionError("FORBIDDEN", {
+      key: "Client.Dashboard.Teams.errorJoinLimit",
+      params: { max: MAX_TEAMS_JOINED_PER_USER },
+    });
   }
 
   const invitationRole = await resolveInvitationRole({
@@ -525,7 +528,7 @@ export async function getPendingInvitationsForCurrentUser() {
   const session = await getSessionFromCookie();
 
   if (!session) {
-    throw new ActionError("NOT_AUTHORIZED", "Not authenticated");
+    throw new ActionError("NOT_AUTHORIZED", { key: "Client.Errors.notAuthenticated" });
   }
 
   const db = getDB();

--- a/src/lib/teams/teams.ts
+++ b/src/lib/teams/teams.ts
@@ -29,7 +29,7 @@ export async function createTeam({
   // Verify user is authenticated
   const session = await requireVerifiedEmail();
   if (!session) {
-    throw new ActionError("NOT_AUTHORIZED", "Not authenticated");
+    throw new ActionError("NOT_AUTHORIZED", { key: "Client.Errors.notAuthenticated" });
   }
 
   const userId = session.userId;
@@ -48,7 +48,10 @@ export async function createTeam({
   const teamsOwned = ownedTeamsCount[0]?.value || 0;
 
   if (teamsOwned >= MAX_TEAMS_CREATED_PER_USER) {
-    throw new ActionError("FORBIDDEN", `You have reached the limit of ${MAX_TEAMS_CREATED_PER_USER} teams you can create.`);
+    throw new ActionError("FORBIDDEN", {
+      key: "Client.Dashboard.Teams.errorCreateLimit",
+      params: { max: MAX_TEAMS_CREATED_PER_USER },
+    });
   }
 
   let slug = generateSlug(name);
@@ -70,7 +73,7 @@ export async function createTeam({
   }
 
   if (!slugIsUnique) {
-    throw new ActionError("ERROR", "Could not generate a unique slug for the team");
+    throw new ActionError("ERROR", { key: "Client.Dashboard.Teams.errorSlugGeneration" });
   }
 
   // Insert the team
@@ -85,7 +88,7 @@ export async function createTeam({
   const team = newTeam?.[0];
 
   if (!team) {
-    throw new ActionError("ERROR", "Could not create team");
+    throw new ActionError("ERROR", { key: "Client.Dashboard.Teams.errorCouldNotCreate" });
   }
 
   const teamId = team.id;
@@ -127,7 +130,7 @@ export const getUserTeams = cache(async () => {
   const session = await requireVerifiedEmail();
 
   if (!session) {
-    throw new ActionError("NOT_AUTHORIZED", "Not authenticated");
+    throw new ActionError("NOT_AUTHORIZED", { key: "Client.Errors.notAuthenticated" });
   }
 
   const db = getDB();

--- a/src/lib/verified-action.ts
+++ b/src/lib/verified-action.ts
@@ -1,11 +1,11 @@
 import "server-only";
 
-import { ActionError } from "@/lib/action-error";
+import { ActionError, type ActionErrorMessageKey } from "@/lib/action-error";
 import { requireVerifiedEmail } from "@/utils/auth";
 
 interface RunVerifiedActionParams<T> {
   actionName: string;
-  failureMessage: string;
+  failureMessageKey: ActionErrorMessageKey;
   handler: () => Promise<T>;
 }
 
@@ -15,13 +15,13 @@ type VerifiedActionResult<T> = T extends void
 
 export async function runVerifiedAction<T>({
   actionName,
-  failureMessage,
+  failureMessageKey,
   handler,
 }: RunVerifiedActionParams<T>): Promise<VerifiedActionResult<T>> {
   const session = await requireVerifiedEmail();
 
   if (!session) {
-    throw new ActionError("NOT_AUTHORIZED", "Not authenticated");
+    throw new ActionError("NOT_AUTHORIZED", { key: "Client.Errors.notAuthenticated" });
   }
 
   try {
@@ -39,6 +39,6 @@ export async function runVerifiedAction<T>({
       throw error;
     }
 
-    throw new ActionError("INTERNAL_SERVER_ERROR", failureMessage);
+    throw new ActionError("INTERNAL_SERVER_ERROR", { key: failureMessageKey });
   }
 }

--- a/src/utils/auth-redirect.ts
+++ b/src/utils/auth-redirect.ts
@@ -2,9 +2,11 @@ import "server-only";
 
 import type { Route } from "next";
 import { headers } from "next/headers";
-import { redirect } from "next/navigation";
+import { redirect as nextRedirect } from "next/navigation";
+import { getLocale } from "next-intl/server";
 
 import { REDIRECT_AFTER_SIGN_IN, SITE_URL } from "@/constants";
+import { redirect } from "@/i18n/navigation";
 import { getSessionFromCookie } from "@/utils/auth";
 import type { SessionValidationResult } from "@/types";
 
@@ -40,6 +42,17 @@ export function getSafeRedirectPath({
   }
 }
 
+// Authed sections (`/dashboard`, `/settings`) live outside `[locale]`, so plain
+// `redirect("/sign-in")` drops the active locale prefix. Builds the `redirect`
+// query param itself — the sign-in page only honors `?redirect=`.
+export async function redirectToSignIn(returnTo?: string): Promise<never> {
+  const locale = await getLocale();
+  const href = returnTo
+    ? `/sign-in?redirect=${encodeURIComponent(returnTo)}`
+    : "/sign-in";
+  return redirect({ href, locale });
+}
+
 export async function redirectAuthenticatedUser({
   redirectPath,
   shouldRedirect,
@@ -54,7 +67,8 @@ export async function redirectAuthenticatedUser({
   const isServerActionRequest = requestHeaders.has("next-action") || isRscRequest;
 
   if (session && !isServerActionRequest && (!shouldRedirect || shouldRedirect(session))) {
-    return redirect(redirectPath);
+    // Destination is typically `/dashboard` (outside `[locale]`); keep unprefixed.
+    return nextRedirect(redirectPath);
   }
 
   return session;

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -204,7 +204,7 @@ const getRequiredVerifiedEmail = cache(async (doNotThrowError = false) => {
   }
 
   if (!session) {
-    throw new ActionError("NOT_AUTHORIZED", "Not authenticated");
+    throw new ActionError("NOT_AUTHORIZED", { key: "Client.Errors.notAuthenticated" });
   }
 
   if (!session?.user?.emailVerified) {
@@ -212,7 +212,7 @@ const getRequiredVerifiedEmail = cache(async (doNotThrowError = false) => {
       return null;
     }
 
-    throw new ActionError("FORBIDDEN", "Please verify your email first");
+    throw new ActionError("FORBIDDEN", { key: "Client.Errors.emailVerificationRequired" });
   }
 
   return session;
@@ -232,7 +232,7 @@ const getRequiredAdmin = cache(async (doNotThrowError = false) => {
   }
 
   if (!session) {
-    throw new ActionError("NOT_AUTHORIZED", "Not authenticated");
+    throw new ActionError("NOT_AUTHORIZED", { key: "Client.Errors.notAuthenticated" });
   }
 
   if (session.user.role !== ROLES_ENUM.ADMIN) {
@@ -240,7 +240,7 @@ const getRequiredAdmin = cache(async (doNotThrowError = false) => {
       return null;
     }
 
-    throw new ActionError("FORBIDDEN", "Not authorized");
+    throw new ActionError("FORBIDDEN", { key: "Client.Errors.notAuthorized" });
   }
 
   return session;

--- a/src/utils/blog-author-url.ts
+++ b/src/utils/blog-author-url.ts
@@ -10,12 +10,17 @@ export interface AuthorUrlIdentity {
   email?: string | null
 }
 
-export function getAuthorDisplayName(author: AuthorUrlIdentity): string {
+// `unknownLabel` is required so callers must pass localized copy — no silent
+// English fallback.
+export function getAuthorDisplayName(
+  author: AuthorUrlIdentity,
+  unknownLabel: string,
+): string {
   const fullName = [author.firstName, author.lastName].filter(Boolean).join(" ")
 
   if (fullName) return fullName
 
-  return author.email || "Unknown Author"
+  return author.email || unknownLabel
 }
 
 function getAuthorSlugBase(author: AuthorUrlIdentity): string {

--- a/src/utils/email.test.ts
+++ b/src/utils/email.test.ts
@@ -67,6 +67,7 @@ describe("transactional email", () => {
     expect(renderedEmail.html).toContain("Hola Ana,");
     expect(renderedEmail.subject).toContain("Restablece tu contraseña");
     expect(renderedEmail.html).not.toContain("Reset your");
+    expect(renderedEmail.html).toContain("/es/reset-password?token=");
   });
 
   test("renders the password reset email in English when the payload locale is en", async () => {
@@ -84,6 +85,8 @@ describe("transactional email", () => {
     expect(renderedEmail.html).toContain("Reset your");
     expect(renderedEmail.html).toContain("Hi Ana,");
     expect(renderedEmail.subject).toContain("Reset your password");
+    expect(renderedEmail.html).toContain("/reset-password?token=");
+    expect(renderedEmail.html).not.toContain("/en/reset-password?token=");
   });
 
   test("falls back to the default locale for an unknown payload locale", async () => {

--- a/src/utils/email.tsx
+++ b/src/utils/email.tsx
@@ -5,11 +5,11 @@ import { createTranslator } from "next-intl";
 import {
   EMAIL_VERIFICATION_TOKEN_EXPIRATION_SECONDS,
   SITE_DOMAIN,
-  SITE_URL,
 } from "@/constants";
 import { DEFAULT_LOCALE, LOCALES, type Locale } from "@/i18n/config";
 import { MESSAGE_CATALOGS } from "@/i18n/message-catalogs";
 import { getCloudflareContext } from "@/utils/cloudflare-context";
+import { absoluteLocalizedUrl } from "@/utils/i18n-urls";
 import {
   createScheduledQueueMessage,
   EMAIL_TEMPLATE_TYPES,
@@ -200,7 +200,7 @@ export async function renderTransactionalEmail(
 
   switch (payload.template) {
     case EMAIL_TEMPLATE_TYPES.PASSWORD_RESET: {
-      const resetUrl = `${SITE_URL}/reset-password?token=${payload.data.resetToken}`;
+      const resetUrl = `${absoluteLocalizedUrl({ pathname: "/reset-password", locale })}?token=${payload.data.resetToken}`;
       const emailTemplate = buildEmailTemplate({
         locale,
         title: t("PasswordReset.title", { siteDomain: SITE_DOMAIN }),
@@ -222,7 +222,7 @@ export async function renderTransactionalEmail(
       };
     }
     case EMAIL_TEMPLATE_TYPES.EMAIL_VERIFICATION: {
-      const verificationUrl = `${SITE_URL}/verify-email?token=${payload.data.verificationToken}`;
+      const verificationUrl = `${absoluteLocalizedUrl({ pathname: "/verify-email", locale })}?token=${payload.data.verificationToken}`;
       const expirationHours = EMAIL_VERIFICATION_TOKEN_EXPIRATION_SECONDS / 60 / 60;
       const emailTemplate = buildEmailTemplate({
         locale,
@@ -245,7 +245,7 @@ export async function renderTransactionalEmail(
       };
     }
     case EMAIL_TEMPLATE_TYPES.TEAM_INVITATION: {
-      const inviteUrl = `${SITE_URL}/team-invite?token=${payload.data.invitationToken}`;
+      const inviteUrl = `${absoluteLocalizedUrl({ pathname: "/team-invite", locale })}?token=${payload.data.invitationToken}`;
       const emailTemplate = buildEmailTemplate({
         locale,
         title: t("TeamInvitation.title", { siteDomain: SITE_DOMAIN }),
@@ -286,7 +286,7 @@ export async function sendPasswordResetEmail({
   username: string;
   locale?: Locale;
 }) {
-  const resetUrl = `${SITE_URL}/reset-password?token=${resetToken}`;
+  const resetUrl = `${absoluteLocalizedUrl({ pathname: "/reset-password", locale })}?token=${resetToken}`;
 
   if (!isProd) {
     console.warn('\n\n\nPassword reset url: ', resetUrl)
@@ -318,7 +318,7 @@ export async function sendVerificationEmail({
   username: string;
   locale?: Locale;
 }) {
-  const verificationUrl = `${SITE_URL}/verify-email?token=${verificationToken}`;
+  const verificationUrl = `${absoluteLocalizedUrl({ pathname: "/verify-email", locale })}?token=${verificationToken}`;
 
   if (!isProd) {
     console.warn('\n\n\nVerification url: ', verificationUrl)
@@ -352,7 +352,7 @@ export async function sendTeamInvitationEmail({
   inviterName: string;
   locale?: Locale;
 }) {
-  const inviteUrl = `${SITE_URL}/team-invite?token=${invitationToken}`;
+  const inviteUrl = `${absoluteLocalizedUrl({ pathname: "/team-invite", locale })}?token=${invitationToken}`;
 
   if (!isProd) {
     console.warn('\n\n\nTeam invitation url: ', inviteUrl)

--- a/src/utils/format-date.test.ts
+++ b/src/utils/format-date.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "vitest";
+
+import { formatDate, formatDateTime } from "./format-date";
+
+describe("formatDate", () => {
+  test("formats with the requested locale", () => {
+    const date = new Date("2024-06-15T12:00:00.000Z");
+
+    expect(formatDate(date, "en")).toBe("Jun 15, 2024");
+    expect(formatDate(date, "es")).toMatch(/15/);
+    expect(formatDate(date, "es")).not.toBe(formatDate(date, "en"));
+  });
+});
+
+describe("formatDateTime", () => {
+  test("formats with the requested locale", () => {
+    const date = new Date("2024-06-15T12:00:00.000Z");
+
+    expect(formatDateTime(date, "en")).toContain("2024");
+    expect(formatDateTime(date, "es")).toContain("2024");
+    expect(formatDateTime(date, "es")).not.toBe(formatDateTime(date, "en"));
+  });
+});

--- a/src/utils/format-date.ts
+++ b/src/utils/format-date.ts
@@ -1,27 +1,41 @@
 import { formatDistanceToNow } from "date-fns";
+import { enUS, es } from "date-fns/locale";
 
-export function formatDate(date: string | Date): string {
-  const dateObj = typeof date === 'string' ? new Date(date) : date;
+import { type Locale } from "@/i18n/config";
 
-  return new Intl.DateTimeFormat('en-US', {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-    timeZone: 'UTC',
+const DATE_FNS_LOCALES = {
+  en: enUS,
+  es,
+} as const satisfies Record<Locale, typeof enUS>;
+
+// `locale` is required (no default) so TypeScript surfaces every call site
+// that would otherwise silently format in the default locale. English-only
+// surfaces (admin/CMS) pass DEFAULT_LOCALE explicitly.
+export function formatDate(date: string | Date, locale: Locale): string {
+  const dateObj = typeof date === "string" ? new Date(date) : date;
+
+  return new Intl.DateTimeFormat(locale, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    timeZone: "UTC",
   }).format(dateObj);
 }
 
-export function formatDateTime(date: string | Date | number): string {
-  return new Date(date).toLocaleDateString('en-US', {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-    timeZone: 'UTC',
+export function formatDateTime(date: string | Date | number, locale: Locale): string {
+  return new Date(date).toLocaleDateString(locale, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    timeZone: "UTC",
   });
 }
 
-export function formatRelativeDateTime(date: string | Date | number): string {
-  return formatDistanceToNow(new Date(date), { addSuffix: true });
+export function formatRelativeDateTime(date: string | Date | number, locale: Locale): string {
+  return formatDistanceToNow(new Date(date), {
+    addSuffix: true,
+    locale: DATE_FNS_LOCALES[locale],
+  });
 }

--- a/src/utils/format-price.ts
+++ b/src/utils/format-price.ts
@@ -1,7 +1,11 @@
-// Formats a Stripe smallest-unit amount (e.g. cents) in the viewer's locale. Shared by
-// billing UI on both server and client; whole amounts drop the fraction digits.
-export function formatPrice({ amount, currency }: { amount: number; currency: string }): string {
-  return new Intl.NumberFormat(undefined, {
+import type { Locale } from "@/i18n/config";
+
+// Formats a Stripe smallest-unit amount (e.g. cents) in the viewer's app locale. Shared
+// by billing UI on both server and client; whole amounts drop the fraction digits.
+// The locale is explicit because `undefined` would use the runtime's default locale,
+// which on the server is the Worker's, not the visitor's.
+export function formatPrice({ amount, currency, locale }: { amount: number; currency: string; locale: Locale }): string {
+  return new Intl.NumberFormat(locale, {
     style: "currency",
     currency: currency.toUpperCase(),
     minimumFractionDigits: amount % 100 === 0 ? 0 : 2,

--- a/src/utils/i18n-metadata.ts
+++ b/src/utils/i18n-metadata.ts
@@ -1,10 +1,30 @@
 import "server-only";
 
 import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
 
-import { I18N_ENABLED } from "@/constants";
-import { DEFAULT_LOCALE, type Locale } from "@/i18n/config";
+import { I18N_ENABLED, SITE_NAME } from "@/constants";
+import { DEFAULT_LOCALE, getOpenGraphLocales, type Locale } from "@/i18n/config";
 import { absoluteLocalizedUrl } from "@/utils/i18n-urls";
+
+// Complete site-default OpenGraph object for a locale. Both the root layout and
+// app/[locale]/layout.tsx must emit the FULL object: a child segment's `openGraph`
+// replaces the parent's wholesale, so overriding with locale fields alone drops
+// title/description/siteName. The [locale] layout re-emits it (rather than
+// inheriting) because the root layout cannot see the [locale] param during
+// static generation.
+export async function buildSiteOpenGraph(locale: Locale): Promise<Metadata["openGraph"]> {
+  const t = await getTranslations({ locale, namespace: "Client.Landing.meta" });
+
+  return {
+    type: "website",
+    ...getOpenGraphLocales(locale),
+    url: absoluteLocalizedUrl({ pathname: "/", locale }),
+    title: SITE_NAME,
+    description: t("description"),
+    siteName: SITE_NAME,
+  };
+}
 
 interface BuildAlternatesOptions {
   // Locale-agnostic pathname (e.g. "/privacy"), as accepted by `getPathname`.

--- a/src/utils/i18n-urls.ts
+++ b/src/utils/i18n-urls.ts
@@ -2,14 +2,48 @@ import "server-only";
 
 import { SITE_URL } from "@/constants";
 import type { Locale } from "@/i18n/config";
-import { getPathname } from "@/i18n/navigation";
+import { routing } from "@/i18n/routing";
+
+// Deliberately does NOT use `getPathname` from `@/i18n/navigation`: that module is
+// built with next-intl's `createNavigation`, which imports `next/navigation` client
+// hooks that fail to load outside a Next.js module graph (Workers integration
+// tests, queue consumers sending emails). The routing config defines no `pathnames`
+// map, so localizing a pathname is purely a locale-prefix decision.
+type LocalePrefixMode = "always" | "as-needed" | "never";
+
+// Widened via a parameter (not a const annotation, which flow-narrowing defeats)
+// so the branching stays valid if a downstream template changes the routing mode.
+function resolveLocalePrefixMode(
+  prefix: LocalePrefixMode | { mode?: LocalePrefixMode } | undefined,
+): LocalePrefixMode {
+  if (typeof prefix === "object") {
+    return prefix.mode ?? "always";
+  }
+  // "always" is next-intl's default when unset.
+  return prefix ?? "always";
+}
+
+function localizedPathname({ pathname, locale }: { pathname: string; locale: Locale }): string {
+  const normalized = pathname.startsWith("/") ? pathname : `/${pathname}`;
+  const mode = resolveLocalePrefixMode(routing.localePrefix);
+  const needsPrefix = mode === "never"
+    ? false
+    : mode === "as-needed"
+      ? locale !== routing.defaultLocale
+      : true;
+
+  if (!needsPrefix) {
+    return normalized;
+  }
+
+  return normalized === "/" ? `/${locale}` : `/${locale}${normalized}`;
+}
 
 // Concatenates instead of `new URL(path, SITE_URL)` on purpose: when SITE_URL carries its own base path
 // (e.g. hosted under a subpath), an absolute pathname passed to `new URL` replaces that base path and
 // silently drops it. Joining the strings preserves it; the slash trimming/prefixing just guards against a double or missing separator between the two parts.
 export function absoluteLocalizedUrl({ pathname, locale }: { pathname: string; locale: Locale }): string {
   const siteUrl = SITE_URL.endsWith("/") ? SITE_URL.slice(0, -1) : SITE_URL;
-  const localizedPathname = getPathname({ href: pathname, locale });
 
-  return `${siteUrl}${localizedPathname.startsWith("/") ? localizedPathname : `/${localizedPathname}`}`;
+  return `${siteUrl}${localizedPathname({ pathname, locale })}`;
 }

--- a/src/utils/kv-token.ts
+++ b/src/utils/kv-token.ts
@@ -1,6 +1,6 @@
 import "server-only";
 
-import { ActionError } from "@/lib/action-error";
+import { ActionError, type ActionErrorMessage } from "@/lib/action-error";
 import { getCloudflareContext } from "@/utils/cloudflare-context";
 import { createId } from "@paralleldrive/cuid2";
 
@@ -11,7 +11,8 @@ interface ExpiringTokenPayload {
 
 interface TokenActionError {
   code: string;
-  message: string;
+  // Keyed messages are preferred (translated centrally in safe-action).
+  message: ActionErrorMessage;
 }
 
 interface CreateExpiringTokenParams {

--- a/src/utils/team-auth.ts
+++ b/src/utils/team-auth.ts
@@ -40,13 +40,13 @@ export const requireTeamPermission = cache(async (teamId: string, permission: st
   const session = await requireVerifiedEmail();
 
   if (!session) {
-    throw new ActionError("NOT_AUTHORIZED", "Not authenticated");
+    throw new ActionError("NOT_AUTHORIZED", { key: "Client.Errors.notAuthenticated" });
   }
 
   const hasPermission = await hasTeamPermission(teamId, permission);
 
   if (!hasPermission) {
-    throw new ActionError("FORBIDDEN", "You don't have the required permission in this team");
+    throw new ActionError("FORBIDDEN", { key: "Client.Dashboard.Teams.errorTeamPermissionRequired" });
   }
 
   return session;

--- a/src/utils/with-rate-limit.ts
+++ b/src/utils/with-rate-limit.ts
@@ -27,13 +27,13 @@ interface RateLimitConfig {
   deferWrite?: boolean;
 }
 
+// `message` is log-only; `actionClient`'s `handleServerError` builds the
+// localized user-facing copy from `retryAfterSeconds`.
 export class RateLimitError extends Error {
   readonly retryAfterSeconds: number;
 
   constructor(retryAfterSeconds: number) {
-    const retryAfterMinutes = Math.ceil(retryAfterSeconds / 60);
-
-    super(`Rate limit exceeded. Try again in ${retryAfterMinutes} minutes.`);
+    super(`Rate limit exceeded. Try again in ${retryAfterSeconds}s.`);
     this.name = "RateLimitError";
     this.retryAfterSeconds = retryAfterSeconds;
   }


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR expands internationalization across the application. The main changes are:

- Localized authentication, settings, dashboard, billing, CMS, blog, and documentation flows.
- Structured translation keys for server-action errors.
- Locale-aware links, redirects, metadata, dates, prices, pagination, and emails.
- Query-string and fragment preservation when switching locales.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

The locale switch now retains encoded redirect parameters and URL fragments.

No blocking issue remains in the reviewed fix.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Compared the pre-change destination behavior, confirming the destination was /es without a query string or hash.
- Compared the post-change destination behavior, confirming the destination is /es?campaign=summer&ref=locale-proof#features.
- Captured the after-state visuals showing the Spanish destination with the preserved query and the open locale menu.
- Ran two browser runs to validate the changes against expected assertions; both runs passed.
- Compiled and uploaded visual artifacts (before, after, and UI-state images) for reviewer inspection.

<a href="https://app.greptile.com/trex/runs/14517345/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/components/locale-switcher.tsx | Preserves the current query string and fragment when changing locales. |
| src/i18n/navigation.ts | Centralizes locale-aware pathname, router, link, and redirect helpers. |
| src/lib/action-error.ts | Adds structured translation keys and parameters for action errors. |
| src/utils/format-date.ts | Makes date and relative-time formatting locale-aware. |
| src/utils/i18n-urls.ts | Builds absolute localized URLs without importing client navigation hooks. |


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/components/locale-switcher.tsx`, line 41 ([link](https://github.com/lubomirgeorgiev/cloudflare-workers-nextjs-saas-template/blob/625fc58b763660434828fb54f0a4716d9f08c1a0/src/components/locale-switcher.tsx#L41)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Locale Switch Drops Redirect State**

   `usePathname()` excludes the query string, so this locale change drops parameters from the current URL. For example, switching languages on `/es/sign-in?redirect=/team-invite?token=...` removes the invitation destination, and sign-in then sends the user to the default dashboard instead of continuing the invite flow.

   **Context Used:** CLAUDE.md ([source](https://app.greptile.com/cloudflare-workers-nextjs-saas-template/github/LubomirGeorgiev/cloudflare-workers-nextjs-saas-template/-/custom-context?memory=a977a82e-9657-4528-ab25-8704749c2607))
   
   <details><summary><strong>Artifacts</strong></summary><br />
   
   **[▶ Screen recording from the T-Rex run](https://app.greptile.com/trex/artifacts/20ebd1b0-e9ca-49d5-9844-51029649c2e6)**
   
   - Shows the flow or interaction that T-Rex exercised.
   
   **[▶ Screen recording from the T-Rex run](https://app.greptile.com/trex/artifacts/c7ef3bcc-1a9e-4061-85c9-8dcb4c6eb887)**
   
   - Shows the flow or interaction that T-Rex exercised.
   
   **[Before: Locale Switcher Poster](https://app.greptile.com/trex/artifacts/e691702b-d587-44cf-a9bf-969c8756b3e0)**
   
   - Shows the rendered state that T-Rex checked.
   
   **[After: Locale Switcher Poster](https://app.greptile.com/trex/artifacts/4af4ed39-a006-47d5-9442-232c7349e010)**
   
   - Shows the rendered state that T-Rex checked.
   
   **[Repro: executed Playwright trace recording the original URL, resulting URL, and missing redirect parameter](https://app.greptile.com/trex/artifacts/90c7a982-5f8d-44c3-a863-104523b73058)**
   
   - Keeps the command output available without making the summary code-heavy.
   
   **[Repro: rerunnable Playwright interaction and capture script](https://app.greptile.com/trex/artifacts/fb5d1da4-9dd7-4530-aad7-a8eb152ec221)**
   
   - Contains supporting evidence from the run (text/javascript; charset=utf-8).
   
   **[Repro: runtime harness mounting the real repository LocaleSwitcher component](https://app.greptile.com/trex/artifacts/6f846c2c-db3b-4b62-9763-56518829c1b4)**
   
   - Contains supporting evidence from the run (text/tsx; charset=utf-8).
   
   **[Repro: Vite harness configuration and focused next-intl navigation mocks](https://app.greptile.com/trex/artifacts/0e207cb1-5097-4bf0-8853-4b6ada0fd6e9)**
   
   - Contains supporting evidence from the run (text/typescript; charset=utf-8).
   
   <a href="https://app.greptile.com/trex/runs/14514970/artifacts?artifact=20ebd1b0-e9ca-49d5-9844-51029649c2e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"></picture></a>
   </details>
   
   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
   
   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lubomirgeorgiev%2Fcloudflare-workers-nextjs-saas-template%22%20on%20the%20existing%20branch%20%22fix-i18n%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix-i18n%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fcomponents%2Flocale-switcher.tsx%0ALine%3A%2041%0A%0AComment%3A%0A**Locale%20Switch%20Drops%20Redirect%20State**%0A%0A%60usePathname%28%29%60%20excludes%20the%20query%20string%2C%20so%20this%20locale%20change%20drops%20parameters%20from%20the%20current%20URL.%20For%20example%2C%20switching%20languages%20on%20%60%2Fes%2Fsign-in%3Fredirect%3D%2Fteam-invite%3Ftoken%3D...%60%20removes%20the%20invitation%20destination%2C%20and%20sign-in%20then%20sends%20the%20user%20to%20the%20default%20dashboard%20instead%20of%20continuing%20the%20invite%20flow.%0A%0A**Context%20Used%3A**%20CLAUDE.md%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Fcloudflare-workers-nextjs-saas-template%2Fgithub%2FLubomirGeorgiev%2Fcloudflare-workers-nextjs-saas-template%2F-%2Fcustom-context%3Fmemory%3Da977a82e-9657-4528-ab25-8704749c2607%29%29%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lubomirgeorgiev%2Fcloudflare-workers-nextjs-saas-template&pr=50&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix(i18n): preserve query string and has..."](https://github.com/lubomirgeorgiev/cloudflare-workers-nextjs-saas-template/commit/d66177f73b5a5e82ebaea50b301f15fc1466e5ad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44401849)</sub>

<!-- /greptile_comment -->